### PR TITLE
Update zstream's elem type

### DIFF
--- a/usr/src/uts/common/fs/zfs/sys/dmu_zfetch.h
+++ b/usr/src/uts/common/fs/zfs/sys/dmu_zfetch.h
@@ -50,7 +50,7 @@ typedef struct zstream {
 	uint64_t	zst_cap;	/* prefetch limit (cap), in blocks */
 	kmutex_t	zst_lock;	/* protects stream */
 	clock_t		zst_last;	/* lbolt of last prefetch */
-	avl_node_t	zst_node;	/* embed avl node here */
+	list_node_t	zst_node;	/* embed avl node here */
 } zstream_t;
 
 typedef struct zfetch {


### PR DESCRIPTION
ZFS organize zstream with list,not avl_node_t , zfs convert avl_node\* to list\* before. The zst_node's type is  incorrent,although it works well before.
