### PR TITLE
Update metaslab.c

### DIFF
--- a/usr/src/uts/common/fs/zfs/metaslab.c
+++ b/usr/src/uts/common/fs/zfs/metaslab.c
@@ -271,7 +271,7 @@ metaslab_compare(const void *x1, const void *x2)
 
 /*
  * Update the allocatable flag and the metaslab group's capacity.
- * The allocatable flag is set to true if the capacity is below
+ * The allocatable flag is set to true if the capacity is above
  * the zfs_mg_noalloc_threshold. If a metaslab group transitions
  * from allocatable to non-allocatable or vice versa then the metaslab
  * group's class is updated to reflect the transition.


### PR DESCRIPTION
The comment of the function "metaslab_group_alloc_update" seems to be wrong,
The allocatable flag is set to true When the free capacity is above the
zfs_mg_noalloc_threshold.
