### PR TITLE
ASSERT supported zio types for file and disk vdevs

### DIFF
--- a/usr/src/uts/common/fs/zfs/vdev_disk.c
+++ b/usr/src/uts/common/fs/zfs/vdev_disk.c
@@ -796,6 +796,8 @@ vdev_disk_io_start(zio_t *zio)
 		return;
 	}
 
+	ASSERT(zio->io_type == ZIO_TYPE_READ || zio->io_type == ZIO_TYPE_WRITE);
+
 	vb = kmem_alloc(sizeof (vdev_buf_t), KM_SLEEP);
 
 	vb->vb_io = zio;

--- a/usr/src/uts/common/fs/zfs/vdev_file.c
+++ b/usr/src/uts/common/fs/zfs/vdev_file.c
@@ -211,6 +211,8 @@ vdev_file_io_start(zio_t *zio)
 		return;
 	}
 
+	ASSERT(zio->io_type == ZIO_TYPE_READ || zio->io_type == ZIO_TYPE_WRITE);
+
 	vb = kmem_alloc(sizeof (vdev_buf_t), KM_SLEEP);
 
 	vb->vb_io = zio;


### PR DESCRIPTION
Upstream request for relevant changes committed to FreeBSD by:
https://svnweb.freebsd.org/base?view=revision&revision=274619
