### PR TITLE
Libnsl ip port (or with t_bind)

### DIFF
--- a/usr/src/lib/libnsl/common/mapfile-vers
+++ b/usr/src/lib/libnsl/common/mapfile-vers
@@ -467,6 +467,8 @@ $endif
 
 SYMBOL_VERSION SUNWprivate_1.5 {
     global:
+	svc_tp_create_withbind;
+	svc_tp_create_withport;
 	clnt_create_service_timed;
 	inet_matchaddr;
 } SUNWprivate_1.4;

--- a/usr/src/uts/common/rpc/svc.h
+++ b/usr/src/uts/common/rpc/svc.h
@@ -932,6 +932,39 @@ extern SVCXPRT	*svc_tp_create(void (*)(struct svc_req *, SVCXPRT *),
 	 */
 
 /*
+ * Variant of svc_tp_create that accepts a binding address.
+ * If bindaddr == NULL, this is the same as svc_tp_create().
+ */
+extern SVCXPRT	*svc_tp_create_withbind(void (*)(struct svc_req *, SVCXPRT *),
+				const rpcprog_t, const rpcvers_t,
+				const struct netconfig *,
+			        const struct t_bind *);
+	/*
+	 * void (*dispatch)();			-- dispatch routine
+	 * const rpcprog_t prognum;		-- program number
+	 * const rpcvers_t versnum;		-- version number
+	 * const struct netconfig *nconf;	-- netconfig structure
+	 * const struct t_bind *bindaddr;	-- address to bind
+	 */
+
+/*
+ * Variant of svc_tp_create that accepts an IP port number.
+ * The port number is ignored on transports other than IP.
+ * If portnum = 0, this is the same as svc_tp_create().
+ */
+extern SVCXPRT	*svc_tp_create_withport(void (*)(struct svc_req *, SVCXPRT *),
+				const rpcprog_t, const rpcvers_t,
+				const struct netconfig *,
+			        int portnum);
+	/*
+	 * void (*dispatch)();			-- dispatch routine
+	 * const rpcprog_t prognum;		-- program number
+	 * const rpcvers_t versnum;		-- version number
+	 * const struct netconfig *nconf;	-- netconfig structure
+	 * int portnum;				-- IP port number
+	 */
+
+/*
  * Generic TLI create routine
  */
 extern  SVCXPRT	*svc_tli_create(const int, const struct netconfig *,


### PR DESCRIPTION
Some alternative ideas (and a prototype of them) in response to:
https://github.com/openzfs/openzfs/pull/231

First some background:  Here's a summary of the svc_create interfaces,
ordered from simplest to more complex:

1: Listen on all transports, any address is OK:
```
   svc_create(dispatch_function, program, version, network_type);
```
2: Listen only on some transports, any address is OK:
```
	SVCXPRT *xprt;
	if ((nc = setnetconfig()) == NULL) {
		/* complain... */
		return (-1);
	}
	while (nconf = getnetconfig(nc)) {
		/*
		 * Skip things like tpi_raw, invisible...
		 */
		if ((nconf->nc_flag & NC_VISIBLE) == 0)
			continue;
		if (nconf->nc_semantics != NC_TPI_CLTS &&
		    nconf->nc_semantics != NC_TPI_COTS &&
		    nconf->nc_semantics != NC_TPI_COTS_ORD)
			continue;
		xprt = svc_tp_create(dispatch_function,
		    program, version, nconf);
		/* If additional versions... */
		svc_reg(xprt, program, oldversion, nconf);
		svc_reg(xprt, program, olderversion, nconf);
	}
	(void) endnetconfig(nc);
```
3: Listen only on some transports, bind a specific address:
```
	if ((nc = setnetconfig()) == NULL) {
		/* complain... */
		return (-1);
	}
	while (nconf = getnetconfig(nc)) {
		struct t_bind bind;
		SVCXPRT *xprt;

		/*
		 * Skip things like tpi_raw, invisible...
		 */
		if ((nconf->nc_flag & NC_VISIBLE) == 0)
			continue;
		if (nconf->nc_semantics != NC_TPI_CLTS &&
		    nconf->nc_semantics != NC_TPI_COTS &&
		    nconf->nc_semantics != NC_TPI_COTS_ORD)
			continue;
		/*
		 * Come up with a binding address suitable for
		 * this transport, i.e. netdir_getybyname() or
		 * code specific to IP... (details omitted).
		 */
		fill_in_binding(&bind, nconf);
		xprt = svc_tli_create(RPC_ANYFD, nconf, &bind, 0, 0);
		if (xprt == NULL) {
			/* complain... */
			continue;
		}
		(void) rpcb_unset(prognum, versnum, nconf);
		if (!svc_reg(xprt, prognum, versnum,
		    dispatch_function, nconf)) {
			/* complain... */
			SVC_DESTROY(xprt);
			continue;
		}
		/* If additional versions... */
		svc_reg(xprt, program, oldversion, nconf);
		svc_reg(xprt, program, olderversion, nconf);
	}
	(void) endnetconfig(nc);
```
4: Listen only on some transport types, bind a specific address,
   with complete control over socket options and bindings:
```
	As in 3 above, but instead of passing RPC_ANYFD to
	svc_tli_create(), open an FD with t_open(...), then
	set options etc, do t_bind(...), then pass that FD to
	svc_tli_create()...  (other details omitted)
```
( end of RPC over TLI background )


Now back to the problem at hand:

We'd like to bind some RPC service listener endpoints on
specific IP ports instead of letting bind pick a port.
(This is desired in nfs/statd and nfs/mountd.)

The current RPC interfaces requires adding code like "form 3"
(above) to every program that wants to use fixed IP ports.
I was curious how hard that is and did it; and after looking
at the result I agree that it lacks convenience.


So, what new convenience function makes sense?

I'd propose a slightly enhanced version of svc_tp_create:
```
	extern SVCXPRT *
	svc_tp_create_withport(void (*)(struct svc_req *, SVCXPRT *),
				const rpcprog_t, const rpcvers_t,
				const struct netconfig *,
				int portnum);
	(where portnum is ignored for non-IP transports)
```
Consuming programs would use it like in "form 2" above:
```
	if ((nc = setnetconfig()) == NULL) {
		/* complain... */
		return (-1);
	}
	while (nconf = getnetconfig(nc)) {
		/*
		 * Skip things like tpi_raw, invisible...
		 */
		if ((nconf->nc_flag & NC_VISIBLE) == 0)
			continue;
		if (nconf->nc_semantics != NC_TPI_CLTS &&
		    nconf->nc_semantics != NC_TPI_COTS &&
		    nconf->nc_semantics != NC_TPI_COTS_ORD)
			continue;
		svc_tp_create_withport(dispatch_function,
		    program, version, nconf, ip_port);
		/* If additional versions... */
		svc_reg(xprt, program, oldversion, nconf);
		svc_reg(xprt, program, olderversion, nconf);
	}
	(void) endnetconfig(nc);
```

The interface here is a compromise, allowing fairly simple changes
in the RPC library, and modest additional complexity in programs
that need to bind fixed ports.  The new RPC library function is a
just a wrapper around the existing svc_tp_create function(s).

I've prototyped these RPC library changes here:
[https://github.com/gwr/illumos-gate/compare/f76886de...libnsl-ip-port]

That includes minimal changes to statd and mountd just to
demonstrate how to use svc_tp_create_withport().  The code
using this in mountd is actually a little shorter than it was.
These worked fine for me with some simple tests.

BTW, I liked your changes to add SMF properties for the ports.
I just didn't take the time to merge that into my prototype.

If you like the (simplified?) libnsl interface proposal,
I suggest we open a new bug just for the libnsl work and
let me take that part; then you finish statd and mountd.
