### PR TITLE
Update smbns_ads.c to add aditional help

### DIFF
--- a/usr/src/lib/smbsrv/libsmbns/common/smbns_ads.c
+++ b/usr/src/lib/smbsrv/libsmbns/common/smbns_ads.c
@@ -1862,7 +1862,7 @@ adjoin_table[] = {
 	{ SMB_ADS_KRB5_PARSE_PRINCIPAL,
 	    "Failed parsing the user principal name." },
 	{ SMB_ADS_KRB5_GET_INIT_CREDS_PW,
-	    "Failed getting initial credentials.  (Wrong password?)" },
+	    "Failed getting initial credentials. (Check your local system time. Wrong password?)" },
 	{ SMB_ADS_KRB5_CC_INITIALIZE,
 	    "Failed initializing the credential cache." },
 	{ SMB_ADS_KRB5_CC_STORE_CRED,


### PR DESCRIPTION
removed typo
added additional help to check local system time.
This was the issue the last few hours with my setup.
So I think this hint might be helpful.