### PR TITLE
zfs holds: In scripted mode, do not pad columns with spaces

### DIFF
--- a/usr/src/cmd/zfs/zfs_main.c
+++ b/usr/src/cmd/zfs/zfs_main.c
@@ -5395,8 +5395,13 @@ print_holds(boolean_t scripted, size_t nwidth, size_t tagwidth, nvlist_t *nvl)
 			(void) strftime(tsbuf, DATETIME_BUF_LEN,
 			    gettext(STRFTIME_FMT_STR), &t);
 
-			(void) printf("%-*s%*c%-*s%*c%s\n", nwidth, zname,
-			    sepnum, sep, tagwidth, tagname, sepnum, sep, tsbuf);
+			if (scripted)
+				(void) printf("%s%c%s%c%s\n", zname,
+				    sep, tagname, sep, tsbuf);
+			else
+				(void) printf("%-*s%*c%-*s%*c%s\n", nwidth,
+				    zname, sepnum, sep, tagwidth, tagname,
+				    sepnum, sep, tsbuf);
 		}
 	}
 }


### PR DESCRIPTION
'zfs holds -H' does not properly output content in scripted mode. It uses a tab instead of two spaces, but it still pads column widths with spaces when it should not.

Before:
 $ /sbin/zfs holds -Hp zstore/svn/base@r325191
zstore/svn/base@r325191 testing                         1509498917
zstore/svn/base@r325191 testing_long_tag_name_here      1509499027

After:
 $ ./zfs holds -Hp zstore/svn/base@r325191
zstore/svn/base@r325191 testing 1509498917
zstore/svn/base@r325191 testing_long_tag_name_here      1509499027
