### PR TITLE
Fix probable boolean logic errors

### DIFF
--- a/usr/src/uts/common/inet/ip/ip6_input.c
+++ b/usr/src/uts/common/inet/ip/ip6_input.c
@@ -2021,8 +2021,8 @@ repeat:
 	 */
 	if (IPP_ENABLED(IPP_LOCAL_IN, ipst) &&
 	    !(iraflags & IRAF_LOOPBACK) &&
-	    (protocol != IPPROTO_ESP || protocol != IPPROTO_AH ||
-	    protocol != IPPROTO_DSTOPTS || protocol != IPPROTO_ROUTING ||
+	    (protocol != IPPROTO_ESP && protocol != IPPROTO_AH &&
+	    protocol != IPPROTO_DSTOPTS && protocol != IPPROTO_ROUTING &&
 	    protocol != IPPROTO_FRAGMENT)) {
 		/*
 		 * Use the interface on which the packet arrived - not where

--- a/usr/src/uts/common/inet/ip/ip_input.c
+++ b/usr/src/uts/common/inet/ip/ip_input.c
@@ -2361,7 +2361,7 @@ ip_fanout_v4(mblk_t *mp, ipha_t *ipha, ip_recv_attr_t *ira)
 	 */
 	if (IPP_ENABLED(IPP_LOCAL_IN, ipst) &&
 	    !(iraflags & IRAF_LOOPBACK) &&
-	    (protocol != IPPROTO_ESP || protocol != IPPROTO_AH)) {
+	    (protocol != IPPROTO_ESP && protocol != IPPROTO_AH)) {
 		/*
 		 * Use the interface on which the packet arrived - not where
 		 * the IP address is hosted.


### PR DESCRIPTION
It seems that the author meant to use && rather than || in these cases. A variable will always be non-equal to at least one of two different constants, so the current expression doesn't make sense.

That said, I can't vouch for the effect of this change because I'm unfamiliar with the codebase. It's likely that it restores the intended behavior of the condition, but someone knowledgeable about the code should verify that.