### PR TITLE
OS uuid string should not refer to Solaris.

### DIFF
--- a/usr/src/uts/common/os/dumpsubr.c
+++ b/usr/src/uts/common/os/dumpsubr.c
@@ -3077,7 +3077,7 @@ dump_set_uuid(const char *uuidstr)
 
 	(void) strncpy(dump_osimage_uuid, uuidstr, 36 + 1);
 
-	cmn_err(CE_CONT, "?This Solaris instance has UUID %s\n",
+	cmn_err(CE_CONT, "?This illumos instance has UUID %s\n",
 	    dump_osimage_uuid);
 
 	return (0);


### PR DESCRIPTION
Hi, working on illumos dump configuration we have found this old reference to Solaris. We have simply replaced it with illumos.