### PR TITLE
SMB3 upstream, part 3

### DIFF
--- a/usr/src/uts/common/fs/smbsrv/smb2_dispatch.c
+++ b/usr/src/uts/common/fs/smbsrv/smb2_dispatch.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2016 Nexenta Systems, Inc.  All rights reserved.
  */
 
 
@@ -958,10 +958,6 @@ smb2sr_go_async(smb_request_t *sr,
 	 * Turn on the "async" flag for both the (synchronous)
 	 * interim response and the (later) async response,
 	 * by storing that in flags before coping into ar.
-	 *
-	 * The "related" flag should always be off for the
-	 * async part because we're no longer operating on a
-	 * sequence of commands when we execute that.
 	 */
 	sr->smb2_hdr_flags |= SMB2_FLAGS_ASYNC_COMMAND;
 	sr->smb2_async_id = (uintptr_t)ar;
@@ -971,8 +967,7 @@ smb2sr_go_async(smb_request_t *sr,
 	ar->ar_cmd_len = sr->smb_data.max_bytes - sr->smb2_cmd_hdr;
 
 	ar->ar_cmd_code = sr->smb2_cmd_code;
-	ar->ar_hdr_flags = sr->smb2_hdr_flags &
-	    ~SMB2_FLAGS_RELATED_OPERATIONS;
+	ar->ar_hdr_flags = sr->smb2_hdr_flags;
 	ar->ar_messageid = sr->smb2_messageid;
 	ar->ar_pid = sr->smb_pid;
 	ar->ar_tid = sr->smb_tid;

--- a/usr/src/uts/common/fs/smbsrv/smb_dispatch.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_dispatch.c
@@ -801,6 +801,8 @@ andx_more:
 		(*sdd->sdt_post_op)(sr);
 		smbsr_cleanup(sr);
 	}
+
+	smb_server_inc_req(server);
 	smb_latency_add_sample(&sds->sdt_lat, gethrtime() - sr->sr_time_start);
 
 	atomic_add_64(&sds->sdt_txb,

--- a/usr/src/uts/common/fs/smbsrv/smb_dispatch.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_dispatch.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
  */
 
 /*
@@ -677,6 +677,9 @@ smb1sr_work(struct smb_request *sr)
 	    sr->smb_uid,
 	    sr->smb_mid);
 	sr->first_smb_com = sr->smb_com;
+
+	/* Need this for early goto report_error cases. */
+	sr->cur_reply_offset = sr->reply.chain_offset;
 
 	if ((session->signing.flags & SMB_SIGNING_CHECK) != 0) {
 		if ((sr->smb_flg2 & SMB_FLAGS2_SMB_SECURITY_SIGNATURE) == 0 ||

--- a/usr/src/uts/common/fs/smbsrv/smb_session.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_session.c
@@ -617,8 +617,7 @@ smb_session_reader(smb_session_t *session)
 			break;
 		}
 
-		/* accounting: requests, received bytes */
-		smb_server_inc_req(sv);
+		/* accounting: received bytes */
 		smb_server_add_rxb(sv,
 		    (int64_t)(hdr.xh_length + NETBIOS_HDR_SZ));
 

--- a/usr/src/uts/common/fs/smbsrv/smb_session.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_session.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2016 Nexenta Systems, Inc.  All rights reserved.
  */
 
 #include <sys/atomic.h>
@@ -602,8 +602,11 @@ smb_session_reader(smb_session_t *session)
 
 		/*
 		 * Allocate a request context, read the whole message.
+		 * If the request alloc fails, we've disconnected and
+		 * won't be able to send the reply anyway, so bail now.
 		 */
-		sr = smb_request_alloc(session, hdr.xh_length);
+		if ((sr = smb_request_alloc(session, hdr.xh_length)) == NULL)
+			break;
 
 		req_buf = (uint8_t *)sr->sr_request_buf;
 		resid = hdr.xh_length;
@@ -1320,7 +1323,8 @@ smb_session_isclient(smb_session_t *sn, const char *client)
  * Allocate an smb_request_t structure from the kmem_cache.  Partially
  * initialize the found/new request.
  *
- * Returns pointer to a request
+ * Returns pointer to a request, or NULL if the session state is
+ * one in which new requests are no longer allowed.
  */
 smb_request_t *
 smb_request_alloc(smb_session_t *session, int req_length)
@@ -1353,7 +1357,36 @@ smb_request_alloc(smb_session_t *session, int req_length)
 		sr->sr_request_buf = kmem_alloc(req_length, KM_SLEEP);
 	sr->sr_magic = SMB_REQ_MAGIC;
 	sr->sr_state = SMB_REQ_STATE_INITIALIZING;
-	smb_slist_insert_tail(&session->s_req_list, sr);
+
+	/*
+	 * Only allow new SMB requests in some states.
+	 */
+	smb_rwx_rwenter(&session->s_lock, RW_WRITER);
+	switch (session->s_state) {
+	case SMB_SESSION_STATE_CONNECTED:
+	case SMB_SESSION_STATE_INITIALIZED:
+	case SMB_SESSION_STATE_ESTABLISHED:
+	case SMB_SESSION_STATE_NEGOTIATED:
+		smb_slist_insert_tail(&session->s_req_list, sr);
+		break;
+
+	default:
+		ASSERT(0);
+		/* FALLTHROUGH */
+	case SMB_SESSION_STATE_DISCONNECTED:
+	case SMB_SESSION_STATE_TERMINATED:
+		/* Disallow new requests in these states. */
+		if (sr->sr_request_buf)
+			kmem_free(sr->sr_request_buf, sr->sr_req_length);
+		sr->session = NULL;
+		sr->sr_magic = 0;
+		mutex_destroy(&sr->sr_mutex);
+		kmem_cache_free(smb_cache_request, sr);
+		sr = NULL;
+		break;
+	}
+	smb_rwx_rwexit(&session->s_lock);
+
 	return (sr);
 }
 


### PR DESCRIPTION
https://www.illumos.org/issues/10967
10967 Deleting directory over CIFS SMB2 fails after visiting in explorer

https://www.illumos.org/issues/10968
10968 Kernel panic in smb_session_delete

https://www.illumos.org/issues/10969
10969 SMB server listener stops after a SYN-ACK flood

https://www.illumos.org/issues/10970
10970 SMB v1 response incorrect when signature verification fails

https://www.illumos.org/issues/10971
10971 SMB2 kstats don't correctly count compound requests
