### PR TITLE
SMB3 upstream, part 8

### DIFF
--- a/usr/src/cmd/idmap/idmapd/adutils.c
+++ b/usr/src/cmd/idmap/idmapd/adutils.c
@@ -21,6 +21,8 @@
 
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
  */
 
 /*
@@ -59,7 +61,7 @@
 #define	UIDNUMBERFILTER	"(&(objectclass=user)(uidNumber=%u))"
 #define	GIDNUMBERFILTER	"(&(objectclass=group)(gidNumber=%u))"
 #define	SANFILTER	"(sAMAccountName=%s)"
-#define	OBJSIDFILTER	"(objectSid=%s)"
+#define	OBJSIDFILTER	"(|(objectSid=%s)(sIDHistory=%s))"
 
 void	idmap_ldap_res_search_cb(LDAP *ld, LDAPMessage **res, int rc,
 		int qid, void *argp);
@@ -792,7 +794,7 @@ idmap_sid2name_batch_add1(idmap_query_state_t *state,
 		return (IDMAP_ERR_SID);
 
 	/* Assemble filter */
-	(void) asprintf(&filter, OBJSIDFILTER, cbinsid);
+	(void) asprintf(&filter, OBJSIDFILTER, cbinsid, cbinsid);
 	if (filter == NULL)
 		return (IDMAP_ERR_MEMORY);
 

--- a/usr/src/lib/nsswitch/ldap/common/ldap_common.c
+++ b/usr/src/lib/nsswitch/ldap/common/ldap_common.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 1999, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
  */
 
 #include "ldap_common.h"
@@ -105,6 +105,7 @@ switch_err(int rc, ns_ldap_error_t *error)
 		return (NSS_SUCCESS);
 
 	case NS_LDAP_NOTFOUND:
+		errno = 0;
 		return (NSS_NOTFOUND);
 
 	case NS_LDAP_PARTIAL:
@@ -124,10 +125,10 @@ switch_err(int rc, ns_ldap_error_t *error)
 /* ARGSUSED */
 nss_status_t
 _nss_ldap_lookup(ldap_backend_ptr be, nss_XbyY_args_t *argp,
-		char *database, char *searchfilter, char *domain,
-		int (*init_filter_cb)(const ns_ldap_search_desc_t *desc,
-		char **realfilter, const void *userdata),
-		const void *userdata)
+    char *database, char *searchfilter, char *domain,
+    int (*init_filter_cb)(const ns_ldap_search_desc_t *desc,
+    char **realfilter, const void *userdata),
+    const void *userdata)
 {
 	int		callbackstat = 0;
 	ns_ldap_error_t	*error = NULL;
@@ -247,10 +248,10 @@ error_out:
 /* ARGSUSED */
 nss_status_t
 _nss_ldap_nocb_lookup(ldap_backend_ptr be, nss_XbyY_args_t *argp,
-		char *database, char *searchfilter, const char * const *attrs,
-		int (*init_filter_cb)(const ns_ldap_search_desc_t *desc,
-		char **realfilter, const void *userdata),
-		const void *userdata)
+    char *database, char *searchfilter, const char * const *attrs,
+    int (*init_filter_cb)(const ns_ldap_search_desc_t *desc,
+    char **realfilter, const void *userdata),
+    const void *userdata)
 {
 	ns_ldap_error_t	*error = NULL;
 	int		rc;
@@ -535,7 +536,7 @@ error_out:
 
 nss_backend_t *
 _nss_ldap_constr(ldap_backend_op_t ops[], int nops, char *tablename,
-		const char **attrs, fnf ldapobj2str)
+    const char **attrs, fnf ldapobj2str)
 {
 	ldap_backend_ptr	be;
 

--- a/usr/src/lib/smbsrv/libfksmbsrv/common/fksmb_idmap.c
+++ b/usr/src/lib/smbsrv/libfksmbsrv/common/fksmb_idmap.c
@@ -20,17 +20,17 @@
  */
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2014 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
  */
 
 /*
  * SMB server interface to idmap
  * (smb_idmap_get..., smb_idmap_batch_...)
  *
- * There are three implementations of this interface:
- *	uts/common/fs/smbsrv/smb_idmap.c (smbsrv kmod)
- *	lib/smbsrv/libfksmbsrv/common/fksmb_idmap.c (libfksmbsrv)
- *	lib/smbsrv/libsmb/common/smb_idmap.c (libsmb)
+ * There are three implementations of this interface.
+ * This is the "fake kernel" version of these routines.  See also:
+ * $SRC/lib/smbsrv/libsmb/common/smb_idmap.c
+ * $SRC/uts/common/fs/smbsrv/smb_idmap.c
  *
  * There are enough differences (relative to the code size)
  * that it's more trouble than it's worth to merge them.
@@ -39,6 +39,7 @@
  *	calls idmap interfaces (libidmap)
  *	uses kmem_... interfaces (libfakekernel)
  *	uses cmn_err instead of syslog, etc.
+ * The code in this variant looks a lot like the one in libsmb.
  */
 
 #include <sys/param.h>
@@ -148,8 +149,7 @@ smb_idmap_batch_create(smb_idmap_batch_t *sib, uint16_t nmap, int flags)
 {
 	idmap_stat	stat;
 
-	if (!sib)
-		return (IDMAP_ERR_ARG);
+	ASSERT(sib != NULL);
 
 	bzero(sib, sizeof (smb_idmap_batch_t));
 	stat = idmap_get_create(&sib->sib_idmaph);
@@ -175,18 +175,16 @@ smb_idmap_batch_create(smb_idmap_batch_t *sib, uint16_t nmap, int flags)
 void
 smb_idmap_batch_destroy(smb_idmap_batch_t *sib)
 {
+	char *domsid;
 	int i;
 
-	if (sib == NULL)
-		return;
+	ASSERT(sib != NULL);
+	ASSERT(sib->sib_maps != NULL);
 
 	if (sib->sib_idmaph) {
 		idmap_get_destroy(sib->sib_idmaph);
 		sib->sib_idmaph = NULL;
 	}
-
-	if (sib->sib_maps == NULL)
-		return;
 
 	if (sib->sib_flags & SMB_IDMAP_ID2SID) {
 		/*
@@ -197,6 +195,16 @@ smb_idmap_batch_destroy(smb_idmap_batch_t *sib)
 			smb_sid_free(sib->sib_maps[i].sim_sid);
 			/* from strdup() in libidmap */
 			free(sib->sib_maps[i].sim_domsid);
+		}
+	} else if (sib->sib_flags & SMB_IDMAP_SID2ID) {
+		/*
+		 * SID prefixes are allocated only when mapping
+		 * SIDs to UID/GID
+		 */
+		for (i = 0; i < sib->sib_nmap; i++) {
+			domsid = sib->sib_maps[i].sim_domsid;
+			if (domsid)
+				smb_mem_free(domsid);
 		}
 	}
 
@@ -225,13 +233,15 @@ smb_idmap_batch_getid(idmap_get_handle_t *idmaph, smb_idmap_t *sim,
 	idmap_stat stat;
 	int flag = 0;
 
-	if (idmaph == NULL || sim == NULL || sid == NULL)
-		return (IDMAP_ERR_ARG);
+	ASSERT(idmaph != NULL);
+	ASSERT(sim != NULL);
+	ASSERT(sid != NULL);
 
 	smb_sid_tostr(sid, sidstr);
 	if (smb_sid_splitstr(sidstr, &sim->sim_rid) != 0)
 		return (IDMAP_ERR_SID);
-	sim->sim_domsid = sidstr;
+	/* Note: Free sim_domsid in smb_idmap_batch_destroy */
+	sim->sim_domsid = smb_mem_strdup(sidstr);
 	sim->sim_idtype = idtype;
 
 	switch (idtype) {
@@ -259,9 +269,6 @@ smb_idmap_batch_getid(idmap_get_handle_t *idmaph, smb_idmap_t *sim,
 		break;
 	}
 
-	/* This was copied by idmap_get_Xbysid. */
-	sim->sim_domsid = NULL;
-
 	return (stat);
 }
 
@@ -272,6 +279,8 @@ smb_idmap_batch_getid(idmap_get_handle_t *idmaph, smb_idmap_t *sim,
  *
  * sim->sim_domsid and sim->sim_rid will contain the mapping
  * result upon successful process of the batched request.
+ * Stash the type for error reporting (caller saves the ID).
+ *
  * NB: sim_domsid allocated by strdup, here or in libidmap
  */
 idmap_stat
@@ -284,6 +293,7 @@ smb_idmap_batch_getsid(idmap_get_handle_t *idmaph, smb_idmap_t *sim,
 	if (!idmaph || !sim)
 		return (IDMAP_ERR_ARG);
 
+	sim->sim_idtype = idtype;
 	switch (idtype) {
 	case SMB_IDMAP_USER:
 		stat = idmap_get_sidbyuid(idmaph, id, flag,
@@ -322,10 +332,33 @@ smb_idmap_batch_getsid(idmap_get_handle_t *idmaph, smb_idmap_t *sim,
 		break;
 
 	default:
+		ASSERT(0);
 		return (IDMAP_ERR_ARG);
 	}
 
 	return (stat);
+}
+
+static void
+smb_idmap_bgm_report(smb_idmap_batch_t *sib, smb_idmap_t *sim)
+{
+
+	if ((sib->sib_flags & SMB_IDMAP_ID2SID) != 0) {
+		/*
+		 * Note: The ID and type we asked idmap to map
+		 * were saved in *sim_id and sim_idtype.
+		 */
+		uint_t id = (sim->sim_id == NULL) ?
+		    0 : (uint_t)*sim->sim_id;
+		cmn_err(CE_WARN, "Can't get SID for "
+		    "ID=%u type=%d, status=%d",
+		    id, sim->sim_idtype, sim->sim_stat);
+	}
+
+	if ((sib->sib_flags & SMB_IDMAP_SID2ID) != 0) {
+		cmn_err(CE_WARN, "Can't get ID for SID %s-%u, status=%d",
+		    sim->sim_domsid, sim->sim_rid, sim->sim_stat);
+	}
 }
 
 /*
@@ -353,13 +386,10 @@ smb_idmap_batch_getmappings(smb_idmap_batch_t *sib)
 	 */
 	for (i = 0, sim = sib->sib_maps; i < sib->sib_nmap; i++, sim++) {
 		if (sim->sim_stat != IDMAP_SUCCESS) {
-			if (sib->sib_flags == SMB_IDMAP_SID2ID) {
-				cmn_err(CE_NOTE, "[%d] %d (%d)",
-				    sim->sim_idtype,
-				    sim->sim_rid,
-				    sim->sim_stat);
+			smb_idmap_bgm_report(sib, sim);
+			if ((sib->sib_flags & SMB_IDMAP_SKIP_ERRS) == 0) {
+				return (sim->sim_stat);
 			}
-			return (sim->sim_stat);
 		}
 	}
 
@@ -389,6 +419,7 @@ smb_idmap_batch_binsid(smb_idmap_batch_t *sib)
 
 	sim = sib->sib_maps;
 	for (i = 0; i < sib->sib_nmap; sim++, i++) {
+		ASSERT(sim->sim_domsid != NULL);
 		if (sim->sim_domsid == NULL)
 			return (-1);
 

--- a/usr/src/lib/smbsrv/libmlsvc/common/smb_logon.c
+++ b/usr/src/lib/smbsrv/libmlsvc/common/smb_logon.c
@@ -21,7 +21,7 @@
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2016 by Delphix. All rights reserved.
- * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
  */
 
 #include <unistd.h>
@@ -129,6 +129,10 @@ smb_token_idmap(smb_token_t *token, smb_idmap_batch_t *sib)
  * smb_token_sids2ids
  *
  * This will map all the SIDs of the access token to UIDs/GIDs.
+ * However, if there are some SIDs we can't map to UIDs/GIDs,
+ * we don't want to fail the logon, and instead just log the
+ * SIDs we could not map and continue as best we can.
+ * The flag SMB_IDMAP_SKIP_ERRS below does that.
  *
  * Returns 0 upon success.  Otherwise, returns -1.
  */
@@ -148,7 +152,8 @@ smb_token_sids2ids(smb_token_t *token)
 	else
 		nmaps = token->tkn_win_grps.i_cnt + 3;
 
-	stat = smb_idmap_batch_create(&sib, nmaps, SMB_IDMAP_SID2ID);
+	stat = smb_idmap_batch_create(&sib, nmaps,
+	    SMB_IDMAP_SID2ID | SMB_IDMAP_SKIP_ERRS);
 	if (stat != IDMAP_SUCCESS)
 		return (-1);
 

--- a/usr/src/tools/quick/make-idmap
+++ b/usr/src/tools/quick/make-idmap
@@ -11,7 +11,7 @@
 #
 
 #
-# Copyright 2014 Nexenta Systems, Inc.  All rights reserved.
+# Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
 #
 
 # Use distributed make (dmake) by default.
@@ -186,6 +186,8 @@ do_tags() {
 do_tar() {
 	git_rev=`git rev-parse --short=8 HEAD`
 	files="
+kernel/misc/idmap
+kernel/misc/amd64/idmap
 lib/svc/manifest/system/idmap.xml
 usr/lib/idmapd
 usr/lib/libads.so.1

--- a/usr/src/uts/common/fs/smbsrv/smb_idmap.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_idmap.c
@@ -20,24 +20,24 @@
  */
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2013 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
  */
 
 /*
  * SMB server interface to idmap
  * (smb_idmap_get..., smb_idmap_batch_...)
  *
- * There are three implementations of this interface:
- *	uts/common/fs/smbsrv/smb_idmap.c (smbsrv kmod)
- *	lib/smbsrv/libfksmbsrv/common/fksmb_idmap.c (libfksmbsrv)
- *	lib/smbsrv/libsmb/common/smb_idmap.c (libsmb)
+ * There are three implementations of this interface.
+ * This is the kernel version of these routines.  See also:
+ * $SRC/lib/smbsrv/libfksmbsrv/common/fksmb_idmap.c
+ * $SRC/lib/smbsrv/libsmb/common/smb_idmap.c
  *
  * There are enough differences (relative to the code size)
  * that it's more trouble than it's worth to merge them.
  *
  * This one differs from the others in that it:
  *	calls kernel (kidmap_...) interfaces
- *	domain SIDs are shared, not strdup'ed
+ *	returned domain SIDs are shared, not strdup'ed
  */
 
 /*
@@ -174,7 +174,7 @@ smb_idmap_getid(smb_sid_t *sid, uid_t *id, int *idtype)
 idmap_stat
 smb_idmap_batch_create(smb_idmap_batch_t *sib, uint16_t nmap, int flags)
 {
-	ASSERT(sib);
+	ASSERT(sib != NULL);
 
 	bzero(sib, sizeof (smb_idmap_batch_t));
 
@@ -201,11 +201,13 @@ smb_idmap_batch_destroy(smb_idmap_batch_t *sib)
 	char *domsid;
 	int i;
 
-	ASSERT(sib);
-	ASSERT(sib->sib_maps);
+	ASSERT(sib != NULL);
+	ASSERT(sib->sib_maps != NULL);
 
-	if (sib->sib_idmaph)
+	if (sib->sib_idmaph) {
 		kidmap_get_destroy(sib->sib_idmaph);
+		sib->sib_idmaph = NULL;
+	}
 
 	if (sib->sib_flags & SMB_IDMAP_ID2SID) {
 		/*
@@ -226,8 +228,10 @@ smb_idmap_batch_destroy(smb_idmap_batch_t *sib)
 		}
 	}
 
-	if (sib->sib_size && sib->sib_maps)
+	if (sib->sib_size && sib->sib_maps) {
 		kmem_free(sib->sib_maps, sib->sib_size);
+		sib->sib_maps = NULL;
+	}
 }
 
 /*
@@ -249,14 +253,16 @@ smb_idmap_batch_getid(idmap_get_handle_t *idmaph, smb_idmap_t *sim,
 	char strsid[SMB_SID_STRSZ];
 	idmap_stat idm_stat;
 
-	ASSERT(idmaph);
-	ASSERT(sim);
-	ASSERT(sid);
+	ASSERT(idmaph != NULL);
+	ASSERT(sim != NULL);
+	ASSERT(sid != NULL);
 
 	smb_sid_tostr(sid, strsid);
 	if (smb_sid_splitstr(strsid, &sim->sim_rid) != 0)
 		return (IDMAP_ERR_SID);
+	/* Note: Free sim_domsid in smb_idmap_batch_destroy */
 	sim->sim_domsid = smb_mem_strdup(strsid);
+	sim->sim_idtype = idtype;
 
 	switch (idtype) {
 	case SMB_IDMAP_USER:
@@ -290,6 +296,7 @@ smb_idmap_batch_getid(idmap_get_handle_t *idmaph, smb_idmap_t *sim,
  *
  * sim->sim_domsid and sim->sim_rid will contain the mapping
  * result upon successful process of the batched request.
+ * Stash the type for error reporting (caller saves the ID).
  */
 idmap_stat
 smb_idmap_batch_getsid(idmap_get_handle_t *idmaph, smb_idmap_t *sim,
@@ -297,6 +304,7 @@ smb_idmap_batch_getsid(idmap_get_handle_t *idmaph, smb_idmap_t *sim,
 {
 	idmap_stat idm_stat;
 
+	sim->sim_idtype = idtype;
 	switch (idtype) {
 	case SMB_IDMAP_USER:
 		idm_stat = kidmap_batch_getsidbyuid(idmaph, id,
@@ -342,6 +350,28 @@ smb_idmap_batch_getsid(idmap_get_handle_t *idmaph, smb_idmap_t *sim,
 	return (idm_stat);
 }
 
+static void
+smb_idmap_bgm_report(smb_idmap_batch_t *sib, smb_idmap_t *sim)
+{
+
+	if ((sib->sib_flags & SMB_IDMAP_ID2SID) != 0) {
+		/*
+		 * Note: The ID and type we asked idmap to map
+		 * were saved in *sim_id and sim_idtype.
+		 */
+		uint_t id = (sim->sim_id == NULL) ?
+		    0 : (uint_t)*sim->sim_id;
+		cmn_err(CE_WARN, "Can't get SID for "
+		    "ID=%u type=%d, status=%d",
+		    id, sim->sim_idtype, sim->sim_stat);
+	}
+
+	if ((sib->sib_flags & SMB_IDMAP_SID2ID) != 0) {
+		cmn_err(CE_WARN, "Can't get ID for SID %s-%u, status=%d",
+		    sim->sim_domsid, sim->sim_rid, sim->sim_stat);
+	}
+}
+
 /*
  * smb_idmap_batch_getmappings
  *
@@ -356,6 +386,7 @@ idmap_stat
 smb_idmap_batch_getmappings(smb_idmap_batch_t *sib)
 {
 	idmap_stat idm_stat = IDMAP_SUCCESS;
+	smb_idmap_t *sim;
 	int i;
 
 	idm_stat = kidmap_get_mappings(sib->sib_idmaph);
@@ -365,9 +396,13 @@ smb_idmap_batch_getmappings(smb_idmap_batch_t *sib)
 	/*
 	 * Check the status for all the queued requests
 	 */
-	for (i = 0; i < sib->sib_nmap; i++) {
-		if (sib->sib_maps[i].sim_stat != IDMAP_SUCCESS)
-			return (sib->sib_maps[i].sim_stat);
+	for (i = 0, sim = sib->sib_maps; i < sib->sib_nmap; i++, sim++) {
+		if (sim->sim_stat != IDMAP_SUCCESS) {
+			smb_idmap_bgm_report(sib, sim);
+			if ((sib->sib_flags & SMB_IDMAP_SKIP_ERRS) == 0) {
+				return (sim->sim_stat);
+			}
+		}
 	}
 
 	if (smb_idmap_batch_binsid(sib) != 0)
@@ -396,7 +431,7 @@ smb_idmap_batch_binsid(smb_idmap_batch_t *sib)
 
 	sim = sib->sib_maps;
 	for (i = 0; i < sib->sib_nmap; sim++, i++) {
-		ASSERT(sim->sim_domsid);
+		ASSERT(sim->sim_domsid != NULL);
 		if (sim->sim_domsid == NULL)
 			return (1);
 

--- a/usr/src/uts/common/fs/smbsrv/smb_idmap.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_idmap.c
@@ -104,6 +104,14 @@ smb_idmap_getsid(uid_t id, int idtype, smb_sid_t **sid)
 		return (IDMAP_ERR_ARG);
 	}
 
+	/*
+	 * IDMAP_ERR_NOTFOUND is an advisory error
+	 * and idmap will generate a local sid.
+	 */
+	if (sim.sim_stat == IDMAP_ERR_NOTFOUND &&
+	    sim.sim_domsid != NULL)
+		sim.sim_stat = IDMAP_SUCCESS;
+
 	if (sim.sim_stat != IDMAP_SUCCESS)
 		return (sim.sim_stat);
 

--- a/usr/src/uts/common/idmap/idmap_kapi.c
+++ b/usr/src/uts/common/idmap/idmap_kapi.c
@@ -22,6 +22,8 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ *
+ * Copyright 2018 Nexenta Systems, Inc.
  */
 
 /*
@@ -76,8 +78,8 @@ typedef struct idmap_get_res {
 /* Batch mapping handle structure */
 struct idmap_get_handle {
 	struct idmap_zone_specific *zs;
-	int 		mapping_num;
-	int 		mapping_size;
+	int		mapping_num;
+	int		mapping_size;
 	idmap_mapping	*mapping;
 	idmap_get_res	*result;
 };
@@ -88,7 +90,7 @@ typedef struct idmap_zone_specific {
 	zoneid_t	zone_id;
 	kmutex_t	zone_mutex;
 	idmap_cache_t	cache;
-	door_handle_t 	door_handle;
+	door_handle_t	door_handle;
 	int		door_valid;
 	int		door_retried;
 	uint32_t	message_id;
@@ -195,7 +197,7 @@ idmap_get_cache_data(zone_t *zone, size_t *uidbysid, size_t *gidbysid,
 static int
 kidmap_call_door(idmap_zone_specific_t *zs, door_arg_t *arg)
 {
-	door_handle_t 	dh;
+	door_handle_t	dh;
 	door_info_t	di;
 	int		status = 0;
 	int		num_retries = 5;
@@ -819,7 +821,7 @@ kidmap_getsidbygid(zone_t *zone, gid_t gid, const char **sid_prefix,
  * Create handle to get SID to UID/GID mapping entries
  *
  * Input:
- * 	none
+ *	none
  * Return:
  *	get_handle
  *
@@ -898,7 +900,7 @@ kidmap_batch_getuidbysid(idmap_get_handle_t *get_handle, const char *sid_prefix,
     uint32_t rid, uid_t *uid, idmap_stat *stat)
 {
 	idmap_mapping	*mapping;
-	idmap_get_res 	*result;
+	idmap_get_res	*result;
 
 	if (get_handle == NULL || sid_prefix == NULL ||
 	    uid == NULL || stat == NULL)
@@ -959,7 +961,7 @@ kidmap_batch_getgidbysid(idmap_get_handle_t *get_handle, const char *sid_prefix,
     uint32_t rid, uid_t *gid, idmap_stat *stat)
 {
 	idmap_mapping	*mapping;
-	idmap_get_res 	*result;
+	idmap_get_res	*result;
 
 	if (get_handle == NULL || sid_prefix == NULL ||
 	    gid == NULL || stat == NULL)
@@ -1022,7 +1024,7 @@ kidmap_batch_getpidbysid(idmap_get_handle_t *get_handle, const char *sid_prefix,
     uint32_t rid, uid_t *pid, int *is_user, idmap_stat *stat)
 {
 	idmap_mapping	*mapping;
-	idmap_get_res 	*result;
+	idmap_get_res	*result;
 
 	if (get_handle == NULL || sid_prefix == NULL || pid == NULL ||
 	    is_user == NULL || stat == NULL)
@@ -1081,7 +1083,7 @@ kidmap_batch_getsidbyuid(idmap_get_handle_t *get_handle, uid_t uid,
     const char **sid_prefix, uint32_t *rid, idmap_stat *stat)
 {
 	idmap_mapping	*mapping;
-	idmap_get_res 	*result;
+	idmap_get_res	*result;
 
 	if (get_handle == NULL || sid_prefix == NULL ||
 	    rid == NULL || stat == NULL)
@@ -1136,7 +1138,7 @@ kidmap_batch_getsidbygid(idmap_get_handle_t *get_handle, gid_t gid,
     const char **sid_prefix, uint32_t *rid, idmap_stat *stat)
 {
 	idmap_mapping	*mapping;
-	idmap_get_res 	*result;
+	idmap_get_res	*result;
 
 	if (get_handle == NULL || sid_prefix == NULL ||
 	    rid == NULL || stat == NULL)
@@ -1307,6 +1309,12 @@ kidmap_get_mappings(idmap_get_handle_t *get_handle)
 				*result->sid_prefix = sid_prefix;
 				*result->rid = id->idmap_id_u.sid.rid;
 			}
+			if (*result->stat == IDMAP_ERR_NOTFOUND &&
+			    sid_prefix != NULL) {
+				/* IDMAP generated a local SID. Use it. */
+				*result->stat = IDMAP_SUCCESS;
+			}
+
 			if (*result->stat == IDMAP_SUCCESS &&
 			    request->id1.idtype == IDMAP_UID)
 				kidmap_cache_add_sid2uid(
@@ -1401,11 +1409,11 @@ kidmap_rpc_call(idmap_zone_specific_t *zs, uint32_t op, xdrproc_t xdr_args,
 	char		*inbuf_ptr = NULL;
 	size_t		inbuf_size = 4096;
 	char		*outbuf_ptr = NULL;
-	size_t 		outbuf_size = 4096;
+	size_t		outbuf_size = 4096;
 	size_t		size;
 	int		status = 0;
 	door_arg_t	params;
-	int 		retry = 0;
+	int		retry = 0;
 	struct rpc_msg	call_msg;
 
 	params.rbuf = NULL;

--- a/usr/src/uts/common/smbsrv/smb_idmap.h
+++ b/usr/src/uts/common/smbsrv/smb_idmap.h
@@ -22,7 +22,7 @@
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  *
- * Copyright 2014 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
  */
 
 #ifndef _SMB_IDMAP_H
@@ -59,6 +59,7 @@ extern "C" {
 
 #define	SMB_IDMAP_SID2ID	0x0001
 #define	SMB_IDMAP_ID2SID	0x0002
+#define	SMB_IDMAP_SKIP_ERRS	0x0004
 
 /*
  * smb_idmap_t
@@ -79,8 +80,8 @@ typedef struct smb_idmap_batch {
 	uint16_t		sib_nmap;
 	uint32_t		sib_flags;
 	uint32_t		sib_size;
-	smb_idmap_t 		*sib_maps;
-	idmap_get_handle_t 	*sib_idmaph;
+	smb_idmap_t		*sib_maps;
+	idmap_get_handle_t	*sib_idmaph;
 } smb_idmap_batch_t;
 
 idmap_stat smb_idmap_getsid(uid_t, int, smb_sid_t **);


### PR DESCRIPTION
[10992](https://www.illumos.org/issues/10992) SMB logon should tolerate idmap problems
[10993](https://www.illumos.org/issues/10993) SMB can't view permissions when owners not in /etc/passwd
[10994](https://www.illumos.org/issues/10994) Removal of "Read Attributes" prevents reading directory over SMB
[10995](https://www.illumos.org/issues/10995) idmap fails to lookup group SID in AD
[10996](https://www.illumos.org/issues/10996) SMB can't view ACL if posix ID can't be mapped
