### PR TITLE
SMB3 Upstream, part 17 (misc. fixes/enhancements before auditing)

### DIFF
--- a/usr/src/cmd/smbsrv/smbd/server.xml
+++ b/usr/src/cmd/smbsrv/smbd/server.xml
@@ -22,7 +22,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 CDDL HEADER END
 
 Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
-Copyright 2016 Nexenta Systems, Inc.  All rights reserved.
+Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
 Copyright 2016 Hans Rosenfeld <rosenfeld@grumpf.hope-2000.org>
 
 NOTE:  This service manifest is not editable; its contents will
@@ -38,7 +38,7 @@ file.
 <service
     name='network/smb/server'
     type='service'
-    version='1'>
+    version='2'>
 
 	<!-- 2. Create default service instance. -->
 	<create_default_instance enabled='false' />
@@ -192,9 +192,7 @@ file.
 		<propval name='signing_enabled' type='boolean'
 			value='true' override='true'/>
 		<propval name='signing_required' type='boolean'
-			value='false' override='true'/>
-		<propval name='signing_check' type='boolean'
-			value='false' override='true'/>
+			value='true' override='true'/>
 		<propval name='sync_enable' type='boolean'
 			value='false' override='true'/>
 		<propval name='security' type='astring'

--- a/usr/src/lib/smbsrv/libmlsvc/common/smb_quota.c
+++ b/usr/src/lib/smbsrv/libmlsvc/common/smb_quota.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2014 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
  */
 
 #include <stdio.h>
@@ -1083,11 +1083,13 @@ smb_quota_zfs_init(const char *path, smb_quota_zfs_handle_t *zfs_hdl)
 {
 	char dataset[MAXPATHLEN];
 
-	if (smb_getdataset(path, dataset, MAXPATHLEN) != 0)
-		return (NT_STATUS_INVALID_PARAMETER);
-
 	if ((zfs_hdl->z_lib = libzfs_init()) == NULL)
 		return (NT_STATUS_INTERNAL_ERROR);
+
+	if (smb_getdataset(zfs_hdl->z_lib, path, dataset, MAXPATHLEN) != 0) {
+		libzfs_fini(zfs_hdl->z_lib);
+		return (NT_STATUS_INVALID_PARAMETER);
+	}
 
 	zfs_hdl->z_fs = zfs_open(zfs_hdl->z_lib, dataset, ZFS_TYPE_DATASET);
 	if (zfs_hdl->z_fs == NULL) {

--- a/usr/src/lib/smbsrv/libmlsvc/common/smb_share.c
+++ b/usr/src/lib/smbsrv/libmlsvc/common/smb_share.c
@@ -19,7 +19,7 @@
  * CDDL HEADER END
  *
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2017 Nexenta Systems, Inc. All rights reserved.
+ * Copyright 2018 Nexenta Systems, Inc. All rights reserved.
  */
 
 /*
@@ -2240,11 +2240,13 @@ smb_shr_zfs_add(smb_share_t *si)
 	int ret;
 	char buf[MAXPATHLEN];	/* dataset or mountpoint */
 
-	if (smb_getdataset(si->shr_path, buf, MAXPATHLEN) != 0)
-		return;
-
 	if ((libhd = libzfs_init()) == NULL)
 		return;
+
+	if (smb_getdataset(libhd, si->shr_path, buf, MAXPATHLEN) != 0) {
+		libzfs_fini(libhd);
+		return;
+	}
 
 	if ((zfshd = zfs_open(libhd, buf, ZFS_TYPE_FILESYSTEM)) == NULL) {
 		libzfs_fini(libhd);
@@ -2285,11 +2287,13 @@ smb_shr_zfs_remove(smb_share_t *si)
 	int ret;
 	char buf[MAXPATHLEN];	/* dataset or mountpoint */
 
-	if (smb_getdataset(si->shr_path, buf, MAXPATHLEN) != 0)
-		return;
-
 	if ((libhd = libzfs_init()) == NULL)
 		return;
+
+	if (smb_getdataset(libhd, si->shr_path, buf, MAXPATHLEN) != 0) {
+		libzfs_fini(libhd);
+		return;
+	}
 
 	errno = 0;
 	ret = zfs_smb_acl_remove(libhd, buf, si->shr_path, si->shr_name);
@@ -2318,11 +2322,13 @@ smb_shr_zfs_rename(smb_share_t *from, smb_share_t *to)
 	int ret;
 	char dataset[MAXPATHLEN];
 
-	if (smb_getdataset(from->shr_path, dataset, MAXPATHLEN) != 0)
-		return;
-
 	if ((libhd = libzfs_init()) == NULL)
 		return;
+
+	if (smb_getdataset(libhd, from->shr_path, dataset, MAXPATHLEN) != 0) {
+		libzfs_fini(libhd);
+		return;
+	}
 
 	if ((zfshd = zfs_open(libhd, dataset, ZFS_TYPE_FILESYSTEM)) == NULL) {
 		libzfs_fini(libhd);

--- a/usr/src/lib/smbsrv/libmlsvc/common/srvsvc_sd.c
+++ b/usr/src/lib/smbsrv/libmlsvc/common/srvsvc_sd.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
  */
 
 /*
@@ -59,12 +60,15 @@ srvsvc_shareacl_getpath(smb_share_t *si, char *shr_acl_path)
 	zfs_handle_t *zfshd;
 	int ret = 0;
 
-	ret = smb_getdataset(si->shr_path, dataset, MAXPATHLEN);
-	if (ret != 0)
-		return (ret);
-
 	if ((libhd = libzfs_init()) == NULL)
 		return (-1);
+
+	ret = smb_getdataset(libhd, si->shr_path, dataset, MAXPATHLEN);
+	if (ret != 0) {
+		libzfs_fini(libhd);
+		return (ret);
+	}
+
 
 	if ((zfshd = zfs_open(libhd, dataset, ZFS_TYPE_DATASET)) == NULL) {
 		libzfs_fini(libhd);

--- a/usr/src/lib/smbsrv/libsmb/Makefile.com
+++ b/usr/src/lib/smbsrv/libsmb/Makefile.com
@@ -20,30 +20,30 @@
 #
 #
 # Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
-# Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+# Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
 #
 # Copyright (c) 2018, Joyent, Inc.
 
 LIBRARY= libsmb.a
 VERS= .1
 
-OBJS_SHARED = 			\
+OBJS_SHARED =			\
 	smb_cfg_util.o		\
-	smb_door_legacy.o 	\
+	smb_door_legacy.o	\
 	smb_inet.o		\
 	smb_msgbuf.o		\
 	smb_native.o		\
 	smb_oem.o		\
 	smb_sid.o		\
-	smb_string.o 		\
+	smb_string.o		\
 	smb_token.o		\
 	smb_token_xdr.o		\
 	smb_utf8.o		\
 	smb_xdr.o
 
-OBJS_COMMON = 			\
+OBJS_COMMON =			\
 	smb_acl.o		\
-	smb_auth.o 		\
+	smb_auth.o		\
 	smb_cache.o		\
 	smb_cfg.o		\
 	smb_crypt.o		\
@@ -83,7 +83,7 @@ LDLIBS +=	$(MACH_LDLIBS)
 # perfer to keep libs ordered by dependence
 LDLIBS +=	-lscf -lmd -luuid -lpkcs11 -lcryptoutil
 LDLIBS +=	-lsec -lidmap -lreparse -lcmdutils -lavl
-LDLIBS +=	-lnvpair -lresolv -lsocket -lnsl -lc
+LDLIBS +=	-lnvpair -lresolv -lsocket -lnsl -lzfs -lc
 CPPFLAGS +=	$(INCS) -D_REENTRANT
 CPPFLAGS +=	-Dsyslog=smb_syslog
 CERRWARN +=	$(CNOWARN_UNINIT)

--- a/usr/src/lib/smbsrv/libsmb/common/libsmb.h
+++ b/usr/src/lib/smbsrv/libsmb/common/libsmb.h
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
  */
 
 #ifndef	_LIBSMB_H
@@ -186,7 +186,8 @@ extern int smb_smf_restart_service(void);
 extern int smb_smf_maintenance_mode(void);
 
 /* ZFS interface */
-int smb_getdataset(const char *, char *, size_t);
+struct libzfs_handle;
+int smb_getdataset(struct libzfs_handle *, const char *, char *, size_t);
 
 /* Configuration management functions  */
 extern int smb_config_get(smb_cfg_id_t, char *, int);

--- a/usr/src/lib/smbsrv/libsmb/common/smb_cfg.c
+++ b/usr/src/lib/smbsrv/libsmb/common/smb_cfg.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
  */
 
 /*
@@ -165,6 +165,7 @@ static smb_cfg_param_t smb_cfg_table[] =
  */
 static struct str_val
 smb_versions[] = {
+	{ "3.02",	SMB_VERS_3_02 },
 	{ "3.0",	SMB_VERS_3_0 },
 	{ "2.1",	SMB_VERS_2_1 },
 	{ "2.002",	SMB_VERS_2_002 },
@@ -1223,7 +1224,7 @@ smb_config_get_protocol(smb_cfg_id_t id, char *name, uint32_t default_val)
  * whole range that we implement). For that reason, this should usually be the
  * highest protocol version we implement.
  */
-uint32_t max_protocol_default = SMB_VERS_3_0;
+uint32_t max_protocol_default = SMB_VERS_3_02;
 
 uint32_t
 smb_config_get_max_protocol(void)

--- a/usr/src/uts/common/fs/smbsrv/smb2_aapl.c
+++ b/usr/src/uts/common/fs/smbsrv/smb2_aapl.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
  */
 
 /*
@@ -68,8 +68,8 @@ static int smb_aapl_ext_maxlen = 512;
  */
 uint32_t
 smb2_aapl_crctx(smb_request_t *sr,
-	mbuf_chain_t *mbcin,
-	mbuf_chain_t *mbcout)
+    mbuf_chain_t *mbcin,
+    mbuf_chain_t *mbcout)
 {
 	uint32_t cmdcode;
 	uint32_t status;
@@ -105,7 +105,7 @@ smb2_aapl_crctx(smb_request_t *sr,
  */
 static uint32_t
 smb2_aapl_srv_query(smb_request_t *sr,
-	mbuf_chain_t *mbcin, mbuf_chain_t *mbcout)
+    mbuf_chain_t *mbcin, mbuf_chain_t *mbcout)
 {
 	uint64_t client_bitmap;
 	uint64_t client_caps;
@@ -164,8 +164,8 @@ smb2_aapl_srv_query(smb_request_t *sr,
  */
 int
 smb2_aapl_get_macinfo(smb_request_t *sr, smb_odir_t *od,
-	smb_fileinfo_t *fileinfo, smb_macinfo_t *mi,
-	char *tbuf, size_t tbuflen)
+    smb_fileinfo_t *fileinfo, smb_macinfo_t *mi,
+    char *tbuf, size_t tbuflen)
 {
 	int		rc;
 	cred_t		*kcr = zone_kcred();
@@ -224,7 +224,7 @@ smb2_aapl_get_macinfo(smb_request_t *sr, smb_odir_t *od,
 		uio.uio_resid = sizeof (AfpInfo);
 		uio.uio_segflg = UIO_SYSSPACE;
 		uio.uio_extflg = UIO_COPY_DEFAULT;
-		rc = smb_fsop_read(sr, kcr, snode, NULL, &uio);
+		rc = smb_fsop_read(sr, kcr, snode, NULL, &uio, 0);
 		if (rc == 0 && uio.uio_resid == 0) {
 			bcopy(&AfpInfo[4], &mi->mi_finderinfo,
 			    sizeof (mi->mi_finderinfo));

--- a/usr/src/uts/common/fs/smbsrv/smb2_durable.c
+++ b/usr/src/uts/common/fs/smbsrv/smb2_durable.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
  */
 
 /*
@@ -844,7 +844,7 @@ smb2_dh_read_nvlist(smb_request_t *sr, smb_node_t *node,
 	uio.uio_resid = flen;
 	uio.uio_segflg = UIO_SYSSPACE;
 	uio.uio_extflg = UIO_COPY_DEFAULT;
-	rc = smb_fsop_read(sr, kcr, node, NULL, &uio);
+	rc = smb_fsop_read(sr, kcr, node, NULL, &uio, 0);
 	if (rc != 0) {
 		cmn_err(CE_NOTE, "CA import (%s/%s) read, rc=%d",
 		    shr->shr_path, node->od_name, rc);

--- a/usr/src/uts/common/fs/smbsrv/smb2_fsctl_sparse.c
+++ b/usr/src/uts/common/fs/smbsrv/smb2_fsctl_sparse.c
@@ -377,7 +377,7 @@ smb2_sparse_copy(
 			uio.uio_extflg = UIO_COPY_DEFAULT;
 
 			rc = smb_fsop_read(sr, src_ofile->f_cr,
-			    src_ofile->f_node, src_ofile, &uio);
+			    src_ofile->f_node, src_ofile, &uio, 0);
 			if (rc != 0) {
 				status = smb_errno2status(rc);
 				return (status);

--- a/usr/src/uts/common/fs/smbsrv/smb2_negotiate.c
+++ b/usr/src/uts/common/fs/smbsrv/smb2_negotiate.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
  */
 
 /*
@@ -74,6 +74,7 @@ static uint16_t smb2_versions[] = {
 	0x202,	/* SMB 2.002 */
 	0x210,	/* SMB 2.1 */
 	0x300,	/* SMB 3.0 */
+	0x302,	/* SMB 3.02 */
 };
 static uint16_t smb2_nversions =
     sizeof (smb2_versions) / sizeof (smb2_versions[0]);

--- a/usr/src/uts/common/fs/smbsrv/smb2_write.c
+++ b/usr/src/uts/common/fs/smbsrv/smb2_write.c
@@ -20,6 +20,8 @@
 #include <smbsrv/smb2_kproto.h>
 #include <smbsrv/smb_fsops.h>
 
+boolean_t smb_allow_unbuffered = B_TRUE;
+
 smb_sdrc_t
 smb2_write(smb_request_t *sr)
 {
@@ -41,6 +43,7 @@ smb2_write(smb_request_t *sr)
 	int data_chain_off, skip;
 	int stability = 0;
 	int rc = 0;
+	boolean_t unbuffered = B_FALSE;
 
 	/*
 	 * Decode SMB2 Write request
@@ -111,6 +114,19 @@ smb2_write(smb_request_t *sr)
 	if (Length == 0)
 		goto errout;
 
+	/*
+	 * Unbuffered refers to the MS-FSA Write argument by the same name.
+	 * It indicates that the cache for this range should be flushed to disk,
+	 * and data written directly to disk, bypassing the cache.
+	 * We don't allow that degree of cache management.
+	 * Translate this directly as FSYNC,
+	 * which should at least flush the cache.
+	 */
+
+	if (smb_allow_unbuffered &&
+	    (Flags & SMB2_WRITEFLAG_WRITE_UNBUFFERED) != 0)
+		unbuffered = B_TRUE;
+
 	switch (of->f_tree->t_res_type & STYPE_MASK) {
 	case STYPE_DISKTREE:
 	case STYPE_PRINTQ:
@@ -123,8 +139,9 @@ smb2_write(smb_request_t *sr)
 				break;
 			}
 		}
-		if ((Flags & SMB2_WRITEFLAG_WRITE_THROUGH) ||
-		    (of->f_node->flags & NODE_FLAGS_WRITE_THROUGH)) {
+
+		if (unbuffered || (Flags & SMB2_WRITEFLAG_WRITE_THROUGH) != 0 ||
+		    (of->f_node->flags & NODE_FLAGS_WRITE_THROUGH) != 0) {
 			stability = FSYNC;
 		}
 		rc = smb_fsop_write(sr, of->f_cr, of->f_node, of,
@@ -137,7 +154,10 @@ smb2_write(smb_request_t *sr)
 		break;
 
 	case STYPE_IPC:
-		rc = smb_opipe_write(sr, &vdb->vdb_uio);
+		if (unbuffered || (Flags & SMB2_WRITEFLAG_WRITE_THROUGH) != 0)
+			rc = EINVAL;
+		else
+			rc = smb_opipe_write(sr, &vdb->vdb_uio);
 		if (rc == 0)
 			XferCount = Length;
 		break;

--- a/usr/src/uts/common/fs/smbsrv/smb_fsops.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_fsops.c
@@ -1980,7 +1980,7 @@ smb_fsop_lookup(
 	if ((flags & SMB_FOLLOW_LINKS) && (vp->v_type == VLNK) &&
 	    ((attr.sa_dosattr & FILE_ATTRIBUTE_REPARSE_POINT) == 0)) {
 		rc = smb_pathname(sr, od_name, FOLLOW, root_node, dnode,
-		    &lnk_dnode, &lnk_target_node, cr);
+		    &lnk_dnode, &lnk_target_node, cr, NULL);
 
 		if (rc != 0) {
 			/*

--- a/usr/src/uts/common/fs/smbsrv/smb_fsops.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_fsops.c
@@ -1380,7 +1380,7 @@ smb_fsop_freesp(
  */
 int
 smb_fsop_read(smb_request_t *sr, cred_t *cr, smb_node_t *snode,
-    smb_ofile_t *ofile, uio_t *uio)
+    smb_ofile_t *ofile, uio_t *uio, int ioflag)
 {
 	caller_context_t ct;
 	cred_t *kcr = zone_kcred();
@@ -1449,7 +1449,7 @@ smb_fsop_read(smb_request_t *sr, cred_t *cr, smb_node_t *snode,
 		}
 	}
 
-	rc = smb_vop_read(snode->vp, uio, cr);
+	rc = smb_vop_read(snode->vp, uio, ioflag, cr);
 	smb_node_end_crit(snode);
 
 	return (rc);

--- a/usr/src/uts/common/fs/smbsrv/smb_node.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_node.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
  */
 /*
  * SMB Node State Machine
@@ -599,7 +599,7 @@ smb_node_root_init(smb_server_t *sv, smb_node_t **svrootp)
 	 * so need to use kcred, not zone_kcred().
 	 */
 	error = smb_pathname(NULL, zone->zone_rootpath, 0,
-	    smb_root_node, smb_root_node, NULL, svrootp, kcred);
+	    smb_root_node, smb_root_node, NULL, svrootp, kcred, NULL);
 
 	return (error);
 }

--- a/usr/src/uts/common/fs/smbsrv/smb_read.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_read.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
  */
 
 #include <smbsrv/smb_kproto.h>
@@ -438,7 +438,7 @@ smb_common_read(smb_request_t *sr, smb_rw_param_t *param)
 		top = smb_mbuf_allocate(&vdb->vdb_uio);
 
 		rc = smb_fsop_read(sr, sr->user_cr, node, ofile,
-		    &vdb->vdb_uio);
+		    &vdb->vdb_uio, 0);
 
 		sr->raw_data.max_bytes -= vdb->vdb_uio.uio_resid;
 		smb_mbuf_trim(top, sr->raw_data.max_bytes);

--- a/usr/src/uts/common/fs/smbsrv/smb_vops.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_vops.c
@@ -250,12 +250,12 @@ smb_vop_other_opens(vnode_t *vp, int mode)
  */
 
 int
-smb_vop_read(vnode_t *vp, uio_t *uiop, cred_t *cr)
+smb_vop_read(vnode_t *vp, uio_t *uiop, int ioflag, cred_t *cr)
 {
 	int error;
 
 	(void) VOP_RWLOCK(vp, V_WRITELOCK_FALSE, &smb_ct);
-	error = VOP_READ(vp, uiop, 0, cr, &smb_ct);
+	error = VOP_READ(vp, uiop, ioflag, cr, &smb_ct);
 	VOP_RWUNLOCK(vp, V_WRITELOCK_FALSE, &smb_ct);
 	return (error);
 }

--- a/usr/src/uts/common/smbsrv/smb2.h
+++ b/usr/src/uts/common/smbsrv/smb2.h
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
  */
 
 #ifndef _SMB_SMB2_H
@@ -318,9 +318,15 @@ typedef enum {
 #define	SMB2_CLOSE_FLAG_POSTQUERY_ATTRIB	0x0001
 
 /*
+ * SMB2 Read
+ */
+#define	SMB2_READFLAG_READ_UNBUFFERED		0x00000001
+
+/*
  * SMB2 Write
  */
 #define	SMB2_WRITEFLAG_WRITE_THROUGH		0x00000001
+#define	SMB2_WRITEFLAG_WRITE_UNBUFFERED		0x00000002
 
 /*
  * SMB2 Lock Request

--- a/usr/src/uts/common/smbsrv/smb_fsops.h
+++ b/usr/src/uts/common/smbsrv/smb_fsops.h
@@ -22,7 +22,7 @@
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  *
- * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
  */
 
 #ifndef _SMBSRV_SMB_FSOPS_H
@@ -78,7 +78,7 @@ int smb_fsop_freesp(smb_request_t *sr, cred_t *cr, smb_ofile_t *,
 		    off64_t, off64_t);
 
 int smb_fsop_read(smb_request_t *, cred_t *, smb_node_t *, smb_ofile_t *,
-    uio_t *);
+    uio_t *, int);
 
 int smb_fsop_write(smb_request_t *, cred_t *, smb_node_t *, smb_ofile_t *,
     uio_t *, uint32_t *, int);

--- a/usr/src/uts/common/smbsrv/smb_kproto.h
+++ b/usr/src/uts/common/smbsrv/smb_kproto.h
@@ -22,7 +22,7 @@
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2016 Syneto S.R.L.  All rights reserved.
- * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
  */
 
 /*
@@ -552,7 +552,7 @@ int smb_pathname_reduce(smb_request_t *, cred_t *,
     const char *, smb_node_t *, smb_node_t *, smb_node_t **, char *);
 
 int smb_pathname(smb_request_t *, char *, int, smb_node_t *,
-    smb_node_t *, smb_node_t **, smb_node_t **, cred_t *);
+    smb_node_t *, smb_node_t **, smb_node_t **, cred_t *, pathname_t *);
 
 /*
  * smb_notify.c
@@ -861,9 +861,9 @@ boolean_t smb_ace_is_access(int);
 boolean_t smb_ace_is_audit(int);
 
 uint32_t smb_vss_enum_snapshots(smb_request_t *, smb_fsctl_t *);
-int smb_vss_lookup_nodes(smb_request_t *, smb_node_t *, smb_node_t *,
-    char *, smb_node_t **, smb_node_t **);
+int smb_vss_lookup_nodes(smb_request_t *, smb_node_t *, smb_node_t **, char *);
 vnode_t *smb_lookuppathvptovp(smb_request_t *, char *, vnode_t *, vnode_t *);
+int smb_vss_extract_gmttoken(char *, char *);
 
 void smb_panic(char *, const char *, int);
 #pragma	does_not_return(smb_panic)

--- a/usr/src/uts/common/smbsrv/smb_vops.h
+++ b/usr/src/uts/common/smbsrv/smb_vops.h
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2016 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
  */
 
 #ifndef _SMBSRV_SMB_VOPS_H
@@ -125,7 +125,7 @@ void smb_vop_fini(void);
 void smb_vop_start(void);
 int smb_vop_open(vnode_t **, int, cred_t *);
 void smb_vop_close(vnode_t *, int, cred_t *);
-int smb_vop_read(vnode_t *, uio_t *, cred_t *);
+int smb_vop_read(vnode_t *, uio_t *, int, cred_t *);
 int smb_vop_write(vnode_t *, uio_t *, int, uint32_t *, cred_t *);
 int smb_vop_ioctl(vnode_t *, int, void *, cred_t *);
 int smb_vop_getattr(vnode_t *, vnode_t *, smb_attr_t *, int, cred_t *);

--- a/usr/src/uts/common/smbsrv/smbinfo.h
+++ b/usr/src/uts/common/smbsrv/smbinfo.h
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
  */
 
 #ifndef	_SMBSRV_SMBINFO_H
@@ -230,6 +230,7 @@ const char *smbnative_lm_str(smb_version_t *);
 #define	SMB_VERS_2_002		0x202	/* "2.002" */
 #define	SMB_VERS_2_1		0x210	/* "2.1" */
 #define	SMB_VERS_3_0		0x300	/* "3.0" */
+#define	SMB_VERS_3_02		0x302	/* "3.02" */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
[11032](https://www.illumos.org/issues/11032) Time spent sharing SMB filesystems could be reduced by optimizing smb_getdataset for default mount points
[11033](https://www.illumos.org/issues/11033) It's time to require SMB signing by default
[11034](https://www.illumos.org/issues/11034) Restoring previous versions from snapshots doesn't work with nested datasets
[11035](https://www.illumos.org/issues/11035) Minimal SMB 3.0.2 support

FYI: Remaining to upstream: https://github.com/illumos/illumos-gate/compare/master...gwr:smb3o
