### PR TITLE
SMB3 upstream, part 19

### DIFF
--- a/usr/src/cmd/idmap/idmapd/idmap_lsa.c
+++ b/usr/src/cmd/idmap/idmapd/idmap_lsa.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2014 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2019 Nexenta Systems, Inc.  All rights reserved.
  */
 
 /*
@@ -83,9 +83,9 @@ lookup_lsa_by_sid(
 
 	(void) snprintf(sid, sizeof (sid), "%s-%u", sidprefix, rid);
 
-	rc = smb_lookup_sid(sid, &acct);
+	rc = smb_lookup_lsid(sid, &acct);
 	if (rc != 0) {
-		idmapdlog(LOG_ERR, "Error:  smb_lookup_sid failed.");
+		idmapdlog(LOG_ERR, "Error: SMB lookup SID failed.");
 		idmapdlog(LOG_ERR,
 		    "Check SMB service (svc:/network/smb/server).");
 		idmapdlog(LOG_ERR,
@@ -100,7 +100,7 @@ lookup_lsa_by_sid(
 	}
 	if (acct.a_status != NT_STATUS_SUCCESS) {
 		idmapdlog(LOG_WARNING,
-		    "Warning:  smb_lookup_sid(%s) failed (0x%x)",
+		    "Warning:  SMB lookup SID(%s) failed (0x%x)",
 		    sid, acct.a_status);
 		/* Fail soft */
 		ret = IDMAP_ERR_NOTFOUND;
@@ -167,9 +167,9 @@ lookup_lsa_by_name(
 		goto out;
 	}
 
-	rc = smb_lookup_name(namedom, SidTypeUnknown, &acct);
+	rc = smb_lookup_lname(namedom, SidTypeUnknown, &acct);
 	if (rc != 0) {
-		idmapdlog(LOG_ERR, "Error:  smb_lookup_name failed.");
+		idmapdlog(LOG_ERR, "Error: SMB lookup name failed.");
 		idmapdlog(LOG_ERR,
 		    "Check SMB service (svc:/network/smb/server).");
 		idmapdlog(LOG_ERR,
@@ -183,7 +183,7 @@ lookup_lsa_by_name(
 	}
 	if (acct.a_status != NT_STATUS_SUCCESS) {
 		idmapdlog(LOG_WARNING,
-		    "Warning:  smb_lookup_name(%s) failed (0x%x)",
+		    "Warning: SMB lookup name(%s) failed (0x%x)",
 		    namedom, acct.a_status);
 		/* Fail soft */
 		ret = IDMAP_ERR_NOTFOUND;

--- a/usr/src/cmd/mdb/common/modules/smbsrv/smbsrv.c
+++ b/usr/src/cmd/mdb/common/modules/smbsrv/smbsrv.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2017 Nexenta Systems, Inc. All rights reserved.
+ * Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
  */
 
 #include <mdb/mdb_modapi.h>
@@ -1409,6 +1409,12 @@ user_priv_bits[] = {
 	{ "CHANGE_NOTIFY",
 	    SMB_USER_PRIV_CHANGE_NOTIFY,
 	    SMB_USER_PRIV_CHANGE_NOTIFY },
+	{ "READ_FILE",
+	    SMB_USER_PRIV_READ_FILE,
+	    SMB_USER_PRIV_READ_FILE },
+	{ "WRITE_FILE",
+	    SMB_USER_PRIV_WRITE_FILE,
+	    SMB_USER_PRIV_WRITE_FILE },
 	{ NULL, 0, 0 }
 };
 

--- a/usr/src/cmd/smbsrv/smbadm/smbadm.c
+++ b/usr/src/cmd/smbsrv/smbadm/smbadm.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
  */
 
 /*
@@ -178,6 +178,10 @@ static smbadm_prop_handle_t *smbadm_prop_gethandle(char *pname);
 static boolean_t smbadm_chkprop_priv(smbadm_prop_t *prop);
 static int smbadm_setprop_tkowner(char *gname, smbadm_prop_t *prop);
 static int smbadm_getprop_tkowner(char *gname, smbadm_prop_t *prop);
+static int smbadm_setprop_readfile(char *gname, smbadm_prop_t *prop);
+static int smbadm_getprop_readfile(char *gname, smbadm_prop_t *prop);
+static int smbadm_setprop_writefile(char *gname, smbadm_prop_t *prop);
+static int smbadm_getprop_writefile(char *gname, smbadm_prop_t *prop);
 static int smbadm_setprop_backup(char *gname, smbadm_prop_t *prop);
 static int smbadm_getprop_backup(char *gname, smbadm_prop_t *prop);
 static int smbadm_setprop_restore(char *gname, smbadm_prop_t *prop);
@@ -192,6 +196,10 @@ static smbadm_prop_handle_t smbadm_ptable[] = {
 	smbadm_getprop_restore,	smbadm_chkprop_priv	},
 	{"take-ownership", "on|off",	smbadm_setprop_tkowner,
 	smbadm_getprop_tkowner,	smbadm_chkprop_priv	},
+	{"bypass-read", "on|off",	smbadm_setprop_readfile,
+	smbadm_getprop_readfile,	smbadm_chkprop_priv	},
+	{"bypass-write", "on|off",	smbadm_setprop_writefile,
+	smbadm_getprop_writefile,	smbadm_chkprop_priv	},
 	{"description",	"<string>",	smbadm_setprop_desc,
 	smbadm_getprop_desc,	NULL			},
 };
@@ -1804,6 +1812,30 @@ static int
 smbadm_getprop_tkowner(char *gname, smbadm_prop_t *prop)
 {
 	return (smbadm_group_getpriv(gname, SE_TAKE_OWNERSHIP_LUID, prop));
+}
+
+static int
+smbadm_setprop_readfile(char *gname, smbadm_prop_t *prop)
+{
+	return (smbadm_group_setpriv(gname, SE_READ_FILE_LUID, prop));
+}
+
+static int
+smbadm_getprop_readfile(char *gname, smbadm_prop_t *prop)
+{
+	return (smbadm_group_getpriv(gname, SE_READ_FILE_LUID, prop));
+}
+
+static int
+smbadm_setprop_writefile(char *gname, smbadm_prop_t *prop)
+{
+	return (smbadm_group_setpriv(gname, SE_WRITE_FILE_LUID, prop));
+}
+
+static int
+smbadm_getprop_writefile(char *gname, smbadm_prop_t *prop)
+{
+	return (smbadm_group_getpriv(gname, SE_WRITE_FILE_LUID, prop));
 }
 
 static int

--- a/usr/src/lib/smbsrv/libmlsvc/common/libmlsvc.h
+++ b/usr/src/lib/smbsrv/libmlsvc/common/libmlsvc.h
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2019 Nexenta Systems, Inc.  All rights reserved.
  */
 
 #ifndef	_LIBMLSVC_H
@@ -65,7 +65,9 @@ extern "C" {
 #endif
 
 uint32_t lsa_lookup_name(char *, uint16_t, smb_account_t *);
+uint32_t lsa_lookup_lname(char *, uint16_t, smb_account_t *);
 uint32_t lsa_lookup_sid(smb_sid_t *, smb_account_t *);
+uint32_t lsa_lookup_lsid(smb_sid_t *, smb_account_t *);
 
 /*
  * SMB domain API to discover a domain controller and obtain domain

--- a/usr/src/lib/smbsrv/libmlsvc/common/lsalib.h
+++ b/usr/src/lib/smbsrv/libmlsvc/common/lsalib.h
@@ -52,8 +52,6 @@ typedef struct mslsa_sid lsa_sid_t;
 /*
  * lsalib.c
  */
-uint32_t lsa_lookup_name(char *, uint16_t, smb_account_t *);
-uint32_t lsa_lookup_sid(smb_sid_t *, smb_account_t *);
 DWORD lsa_query_primary_domain_info(char *, char *, smb_domain_t *);
 DWORD lsa_query_account_domain_info(char *, char *, smb_domain_t *);
 DWORD lsa_query_dns_domain_info(char *, char *, smb_domain_t *);

--- a/usr/src/lib/smbsrv/libmlsvc/common/mapfile-vers
+++ b/usr/src/lib/smbsrv/libmlsvc/common/mapfile-vers
@@ -20,7 +20,7 @@
 #
 #
 # Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
-# Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
+# Copyright 2019 Nexenta Systems, Inc.  All rights reserved.
 #
 
 #
@@ -45,6 +45,8 @@ SYMBOL_VERSION SUNWprivate {
 	dfs_info_free;
 	dssetup_check_service;
 	dssetup_clear_domain_info;
+	lsa_lookup_lname;
+	lsa_lookup_lsid;
 	lsa_lookup_name;
 	lsa_lookup_sid;
 	mlsvc_disconnect;

--- a/usr/src/lib/smbsrv/libsmb/common/libsmb.h
+++ b/usr/src/lib/smbsrv/libsmb/common/libsmb.h
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2019 Nexenta Systems, Inc.  All rights reserved.
  */
 
 #ifndef	_LIBSMB_H
@@ -722,7 +722,9 @@ boolean_t smb_lgrp_itererror(smb_giter_t *);
 int smb_lgrp_iterate(smb_giter_t *, smb_group_t *);
 
 int smb_lookup_sid(const char *, lsa_account_t *);
+int smb_lookup_lsid(const char *, lsa_account_t *);
 int smb_lookup_name(const char *, sid_type_t, lsa_account_t *);
+int smb_lookup_lname(const char *, sid_type_t, lsa_account_t *);
 
 #define	SMB_LGRP_SUCCESS		0
 #define	SMB_LGRP_INVALID_ARG		1

--- a/usr/src/lib/smbsrv/libsmb/common/mapfile-vers
+++ b/usr/src/lib/smbsrv/libsmb/common/mapfile-vers
@@ -19,7 +19,7 @@
 #
 #
 # Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
-# Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+# Copyright 2019 Nexenta Systems, Inc.  All rights reserved.
 #
 
 #
@@ -268,6 +268,8 @@ SYMBOL_VERSION SUNWprivate {
 	smb_logon_decode;
 	smb_logon_free;
 	smb_logon_xdr;
+	smb_lookup_lname;
+	smb_lookup_lsid;
 	smb_lookup_name;
 	smb_lookup_sid;
 	smb_match_netlogon_seqnum;

--- a/usr/src/lib/smbsrv/libsmb/common/smb_lgrp.c
+++ b/usr/src/lib/smbsrv/libsmb/common/smb_lgrp.c
@@ -22,7 +22,7 @@
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2013 RackTop Systems.
- * Copyright 2016 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
  */
 
 #include <stdlib.h>
@@ -2398,6 +2398,8 @@ smb_lgrp_set_default_privs(smb_group_t *grp)
 {
 	if (smb_strcasecmp(grp->sg_name, "Administrators", 0) == 0) {
 		smb_privset_enable(grp->sg_privs, SE_TAKE_OWNERSHIP_LUID);
+		smb_privset_enable(grp->sg_privs, SE_BACKUP_LUID);
+		smb_privset_enable(grp->sg_privs, SE_RESTORE_LUID);
 		return;
 	}
 

--- a/usr/src/lib/smbsrv/libsmb/common/smb_privilege.c
+++ b/usr/src/lib/smbsrv/libsmb/common/smb_privilege.c
@@ -21,6 +21,8 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ *
+ * Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
  */
 
 /*
@@ -79,7 +81,11 @@ static smb_privinfo_t priv_table[] = {
 	    "Modify firmware environment values", 0 },
 	{ 23, SE_CHANGE_NOTIFY_NAME, "Bypass traverse checking", 0 },
 	{ 24, SE_REMOTE_SHUTDOWN_NAME,
-	    "Force shutdown from a remote system", 0 }
+	    "Force shutdown from a remote system", 0 },
+	{ 25, SE_READ_FILE_NAME,
+	    "Bypass ACL for READ access", PF_PRESENTABLE },
+	{ 26, SE_WRITE_FILE_NAME,
+	    "Bypass ACL for WRITE and DELETE access", PF_PRESENTABLE },
 };
 
 /*

--- a/usr/src/man/man1m/smbadm.1m
+++ b/usr/src/man/man1m/smbadm.1m
@@ -16,9 +16,9 @@
 .\"
 .\"
 .\" Copyright (c) 2009, Sun Microsystems, Inc. All Rights Reserved.
-.\" Copyright 2017 Nexenta Systems, Inc.
+.\" Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
 .\"
-.Dd November 18, 2017
+.Dd June 6, 2019
 .Dt SMBADM 1M
 .Os
 .Sh NAME
@@ -252,6 +252,10 @@ to restore file system objects.
 .It Cm take-ownership Ns = Ns Cm on Ns | Ns Cm off
 Specifies whether members of the SMB local group can take ownership of file
 system objects.
+.It Cm bypass-read Ns = Ns Cm on Ns | Ns Cm off
+Specifies whether members of the SMB local group can always bypass Read access controls.
+.It Cm bypass-write Ns = Ns Cm on Ns | Ns Cm off
+Specifies whether members of the SMB local group can always bypass Write and Delete access controls.
 .El
 .It Xo
 .Cm add-member

--- a/usr/src/uts/common/fs/smbsrv/smb2_dispatch.c
+++ b/usr/src/uts/common/fs/smbsrv/smb2_dispatch.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2019 Nexenta Systems, Inc.  All rights reserved.
  * Copyright 2019 RackTop Systems.
  */
 
@@ -823,18 +823,21 @@ cmd_start:
 	 */
 	if ((sdd->sdt_flags & SDDF_SUPPRESS_UID) == 0 &&
 	    !sr->encrypted && sr->uid_user != NULL &&
-	    (sr->uid_user->u_sign_flags & SMB_SIGNING_CHECK) != 0) {
+	    (sr->uid_user->u_sign_flags & SMB_SIGNING_ENABLED) != 0) {
 		/*
-		 * This request type should be signed, and
-		 * we're configured to require signatures.
+		 * If the request is signed, check the signature.
+		 * Otherwise, if signing is required, deny access.
 		 */
-		if ((sr->smb2_hdr_flags & SMB2_FLAGS_SIGNED) == 0) {
-			smb2sr_put_error(sr, NT_STATUS_ACCESS_DENIED);
-			goto cmd_done;
-		}
-		rc = smb2_sign_check_request(sr);
-		if (rc != 0) {
-			DTRACE_PROBE1(smb2__sign__check, smb_request_t *, sr);
+		if ((sr->smb2_hdr_flags & SMB2_FLAGS_SIGNED) != 0) {
+			rc = smb2_sign_check_request(sr);
+			if (rc != 0) {
+				DTRACE_PROBE1(smb2__sign__check,
+				    smb_request_t *, sr);
+				smb2sr_put_error(sr, NT_STATUS_ACCESS_DENIED);
+				goto cmd_done;
+			}
+		} else if (
+		    (sr->uid_user->u_sign_flags & SMB_SIGNING_CHECK) != 0) {
 			smb2sr_put_error(sr, NT_STATUS_ACCESS_DENIED);
 			goto cmd_done;
 		}

--- a/usr/src/uts/common/fs/smbsrv/smb2_negotiate.c
+++ b/usr/src/uts/common/fs/smbsrv/smb2_negotiate.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2019 Nexenta Systems, Inc.  All rights reserved.
  * Copyright 2019 RackTop Systems.
  */
 
@@ -472,8 +472,7 @@ smb2_nego_validate(smb_request_t *sr, smb_fsctl_t *fsctl)
 	/*
 	 * The spec. says to parse the VALIDATE_NEGOTIATE_INFO here
 	 * and verify that the original negotiate was not modified.
-	 * The only tampering we need worry about is secmode, and
-	 * we're not taking that from the client, so don't bother.
+	 * The request MUST be signed, and we MUST validate the signature.
 	 *
 	 * One interesting requirement here is that we MUST reply
 	 * with exactly the same information as we returned in our
@@ -485,6 +484,9 @@ smb2_nego_validate(smb_request_t *sr, smb_fsctl_t *fsctl)
 	uint32_t capabilities;
 	uint16_t secmode, num_dialects, dialects[8];
 	uint8_t clnt_guid[16];
+
+	if ((sr->smb2_hdr_flags & SMB2_FLAGS_SIGNED) == 0)
+		goto drop;
 
 	if (fsctl->InputCount < 24)
 		goto drop;

--- a/usr/src/uts/common/fs/smbsrv/smb_authenticate.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_authenticate.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
  */
 
 /*
@@ -543,6 +543,12 @@ smb_priv_xlate(smb_token_t *token)
 
 	if (smb_token_query_privilege(token, SE_CHANGE_NOTIFY_LUID))
 		privileges |= SMB_USER_PRIV_CHANGE_NOTIFY;
+
+	if (smb_token_query_privilege(token, SE_READ_FILE_LUID))
+		privileges |= SMB_USER_PRIV_READ_FILE;
+
+	if (smb_token_query_privilege(token, SE_WRITE_FILE_LUID))
+		privileges |= SMB_USER_PRIV_WRITE_FILE;
 
 	return (privileges);
 }

--- a/usr/src/uts/common/fs/smbsrv/smb_common_open.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_common_open.c
@@ -543,6 +543,13 @@ smb_common_open(smb_request_t *sr)
 		    (op->create_disposition == FILE_OVERWRITE))
 			op->desired_access |= FILE_WRITE_DATA;
 
+		/* Dataset roots can't be deleted, so don't set DOC */
+		if ((op->create_options & FILE_DELETE_ON_CLOSE) != 0 &&
+		    (fnode->flags & NODE_FLAGS_VFSROOT) != 0) {
+			status = NT_STATUS_CANNOT_DELETE;
+			goto errout;
+		}
+
 		status = smb_fsop_access(sr, sr->user_cr, fnode,
 		    op->desired_access);
 		if (status != NT_STATUS_SUCCESS)

--- a/usr/src/uts/common/fs/smbsrv/smb_cred.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_cred.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
  */
 
 /*
@@ -96,35 +96,6 @@ smb_cred_create(smb_token_t *token)
 	crsetsid(cr, &ksid, KSID_OWNER);
 	ksidlist = smb_cred_set_sidlist(&token->tkn_win_grps);
 	crsetsidlist(cr, ksidlist);
-
-	/*
-	 * In the AD world, "take ownership privilege" is very much
-	 * like having Unix "root" privileges.  It's normally given
-	 * to members of the "Administrators" group, which normally
-	 * includes the the local Administrator (like root) and when
-	 * joined to a domain, "Domain Admins".
-	 */
-	if (smb_token_query_privilege(token, SE_TAKE_OWNERSHIP_LUID)) {
-		(void) crsetpriv(cr,
-		    PRIV_FILE_CHOWN,
-		    PRIV_FILE_DAC_READ,
-		    PRIV_FILE_DAC_SEARCH,
-		    PRIV_FILE_DAC_WRITE,
-		    PRIV_FILE_OWNER,
-		    NULL);
-	}
-
-	/*
-	 * See smb.4 bypass_traverse_checking
-	 *
-	 * For historical reasons, the Windows privilege is named
-	 * SeChangeNotifyPrivilege, though the description is
-	 * "Bypass traverse checking".
-	 */
-	if (smb_token_query_privilege(token, SE_CHANGE_NOTIFY_LUID)) {
-		(void) crsetpriv(cr, PRIV_FILE_DAC_SEARCH, NULL);
-	}
-
 
 	return (cr);
 }

--- a/usr/src/uts/common/fs/smbsrv/smb_node.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_node.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2019 Nexenta Systems, Inc.  All rights reserved.
  */
 /*
  * SMB Node State Machine
@@ -683,6 +683,11 @@ smb_node_set_delete_on_close(smb_node_t *node, cred_t *cr, uint32_t flags)
 		if (status != 0) {
 			return (status);
 		}
+	}
+
+	/* Dataset roots can't be deleted, so don't set DOC */
+	if ((node->flags & NODE_FLAGS_VFSROOT) != 0) {
+		return (NT_STATUS_CANNOT_DELETE);
 	}
 
 	mutex_enter(&node->n_mutex);

--- a/usr/src/uts/common/smbsrv/smb_door.h
+++ b/usr/src/uts/common/smbsrv/smb_door.h
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2014 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2019 Nexenta Systems, Inc.  All rights reserved.
  */
 
 #ifndef _SMBSRV_SMB_DOOR_H
@@ -70,7 +70,9 @@ typedef enum smb_dopcode {
 	SMB_DR_DFS_GET_REFERRALS,
 	SMB_DR_SHR_HOSTACCESS,
 	SMB_DR_SHR_EXEC,
-	SMB_DR_NOTIFY_DC_CHANGED
+	SMB_DR_NOTIFY_DC_CHANGED,
+	SMB_DR_LOOKUP_LSID,
+	SMB_DR_LOOKUP_LNAME
 } smb_dopcode_t;
 
 struct smb_event;

--- a/usr/src/uts/common/smbsrv/smb_ktypes.h
+++ b/usr/src/uts/common/smbsrv/smb_ktypes.h
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
  */
 
 /*
@@ -1012,6 +1012,8 @@ typedef struct smb_session {
 #define	SMB_USER_PRIV_BACKUP		(1<<17)	/* SE_BACKUP_LUID */
 #define	SMB_USER_PRIV_RESTORE		(1<<18)	/* SE_RESTORE_LUID */
 #define	SMB_USER_PRIV_CHANGE_NOTIFY	(1<<23)	/* SE_CHANGE_NOTIFY_LUID */
+#define	SMB_USER_PRIV_READ_FILE		(1<<25)	/* SE_READ_FILE_LUID */
+#define	SMB_USER_PRIV_WRITE_FILE	(1<<26)	/* SE_WRITE_FILE_LUID */
 
 /*
  * See the long "User State Machine" comment in smb_user.c

--- a/usr/src/uts/common/smbsrv/smb_privilege.h
+++ b/usr/src/uts/common/smbsrv/smb_privilege.h
@@ -22,7 +22,7 @@
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  *
- * Copyright 2014 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
  */
 
 #ifndef _SMB_PRIVILEGE_H
@@ -97,6 +97,8 @@ extern "C" {
 #define	SE_SYSTEM_ENVIRONMENT_NAME	"SeSystemEnvironmentPrivilege"
 #define	SE_CHANGE_NOTIFY_NAME		"SeChangeNotifyPrivilege"
 #define	SE_REMOTE_SHUTDOWN_NAME		"SeRemoteShutdownPrivilege"
+#define	SE_READ_FILE_NAME		"BypassAclRead"
+#define	SE_WRITE_FILE_NAME		"BypassAclWrite"
 
 #define	SE_MIN_LUID			2
 #define	SE_CREATE_TOKEN_LUID		2
@@ -122,7 +124,9 @@ extern "C" {
 #define	SE_SYSTEM_ENVIRONMENT_LUID	22
 #define	SE_CHANGE_NOTIFY_LUID		23
 #define	SE_REMOTE_SHUTDOWN_LUID		24
-#define	SE_MAX_LUID			24
+#define	SE_READ_FILE_LUID		25
+#define	SE_WRITE_FILE_LUID		26
+#define	SE_MAX_LUID			26
 
 /*
  * Privilege attributes


### PR DESCRIPTION
[11038](https://www.illumos.org/issues/11038) SMB2 server should require signed Validate Negotiate requests
[11039](https://www.illumos.org/issues/11039) All zfs/nfs/smb threads in door calls to idle idmap
[11852](https://www.illumos.org/issues/11852) SMB should explicitly fail deletion of mountpoints
[11773](https://www.illumos.org/issues/11773) Need ways to override Domain Admins' full control
[11853](https://www.illumos.org/issues/11853) Administrators should have Backup and Restore privileges by default
[11854](https://www.illumos.org/issues/11854) Domain Admins shouldn't always be Administrators
