### PR TITLE
Fix CTF pointer overrun (in userland)

### DIFF
--- a/usr/src/common/ctf/ctf_lookup.c
+++ b/usr/src/common/ctf/ctf_lookup.c
@@ -133,7 +133,8 @@ ctf_lookup_by_name(ctf_file_t *fp, const char *name)
 
 		for (lp = fp->ctf_lookups; lp->ctl_prefix != NULL; lp++) {
 			if (lp->ctl_prefix[0] == '\0' ||
-			    strncmp(p, lp->ctl_prefix, (size_t)(q - p)) == 0) {
+			    ((size_t)(q - p) >= lp->ctl_len &&
+			     strncmp(p, lp->ctl_prefix, (size_t)(q - p)) == 0)) {
 				for (p += lp->ctl_len; isspace(*p); p++)
 					continue; /* skip prefix and next ws */
 


### PR DESCRIPTION
The problem occured when `p = "s"`, and `lp->ctl_prefix = "struct"`.
`strncmp("s","struct",1)` returns 0, because it checks only the first char.
The following line(137) was advancing `p(="s")` by 6, going over the terminator.
(the value of p can be user controlled)