### PR TITLE
atge: register L1C reset funtction in  atge_l1c_mii_ops table

### DIFF
--- a/usr/src/uts/common/io/atge/atge_main.c
+++ b/usr/src/uts/common/io/atge/atge_main.c
@@ -256,7 +256,7 @@ static	mii_ops_t atge_l1c_mii_ops = {
 	atge_l1c_mii_read,
 	atge_l1c_mii_write,
 	atge_mii_notify,
-	NULL
+	atge_l1c_mii_reset
 };
 
 /*

--- a/usr/src/uts/common/io/atge/atge_mii.c
+++ b/usr/src/uts/common/io/atge/atge_mii.c
@@ -248,14 +248,12 @@ atge_l1c_mii_reset(void *arg)
 	phyaddr = mii_get_addr(atgep->atge_mii);
 
 	/* Reset magic from Linux, via Freebsd */
-	OUTW(atgep, ATGE_GPHY_CTRL,
-	    GPHY_CTRL_HIB_EN | GPHY_CTRL_HIB_PULSE | GPHY_CTRL_SEL_ANA_RESET);
+	OUTW(atgep, ATGE_GPHY_CTRL, GPHY_CTRL_SEL_ANA_RESET);
 	(void) INW(atgep, ATGE_GPHY_CTRL);
 	drv_usecwait(10 * 1000);
 
 	OUTW(atgep, ATGE_GPHY_CTRL,
-	    GPHY_CTRL_EXT_RESET | GPHY_CTRL_HIB_EN | GPHY_CTRL_HIB_PULSE |
-	    GPHY_CTRL_SEL_ANA_RESET);
+	    GPHY_CTRL_EXT_RESET | GPHY_CTRL_SEL_ANA_RESET);
 	(void) INW(atgep, ATGE_GPHY_CTRL);
 	drv_usecwait(10 * 1000);
 


### PR DESCRIPTION
On NIC's with Atheros AR8151 v2.0 the atge driver has a problem if you disconnect the network cable on a running interface.
The error message reads as follows: 

May 23 16:14:56 notebookcg2 atge: [ID 451854 kern.warning] WARNING: atge0: L1C chip detected a fatal error, interrupt status: 200
May 23 16:14:56 notebookcg2 atge: [ID 451854 kern.warning] WARNING: atge0: DMA read error
May 23 16:14:56 notebookcg2 atge: [ID 451854 kern.warning] WARNING: atge0: atge_device_stop() stopping TX/RX MAC timeout

After this error the interface will not work anymore until you remove the interface and reconfigure it again.

With this fix the interface will be reset on link down and will work as intended on link up.

I altered the atge_l1c_mii_reset function and used freebsd driver alc as guidance.