### PR TITLE
Fix use-after-free in btree code

### DIFF
--- a/usr/src/uts/common/fs/zfs/btree.c
+++ b/usr/src/uts/common/fs/zfs/btree.c
@@ -1536,8 +1536,8 @@ zfs_btree_remove_from_node(zfs_btree_t *tree, zfs_btree_core_t *node,
 	zfs_btree_poison_node_at(tree, keep_hdr, keep_hdr->bth_count);
 
 	new_rm_hdr->bth_count = 0;
-	zfs_btree_node_destroy(tree, new_rm_hdr);
 	zfs_btree_remove_from_node(tree, parent, new_rm_hdr);
+	zfs_btree_node_destroy(tree, new_rm_hdr);
 }
 
 /* Remove the element at the specific location. */
@@ -1766,9 +1766,9 @@ zfs_btree_remove_idx(zfs_btree_t *tree, zfs_btree_index_t *where)
 	zfs_btree_poison_node_at(tree, keep_hdr, keep_hdr->bth_count);
 
 	rm_hdr->bth_count = 0;
-	zfs_btree_node_destroy(tree, rm_hdr);
 	/* Remove the emptied node from the parent. */
 	zfs_btree_remove_from_node(tree, parent, rm_hdr);
+	zfs_btree_node_destroy(tree, rm_hdr);
 	zfs_btree_verify(tree);
 }
 


### PR DESCRIPTION
Recently, coverity static analysis found a use-after-free bug in the btree code in openzfs/zfs. It had been detected causing problems in the wild on debug builds in 2020:

https://github.com/openzfs/zfs/issues/10989

On non-debug builds, it will just silently cause undefined behavior. In any case, I could not find my old account for illumos.org, so I decided to file a pull request to inform people since in my opinion, it is a fairly critical bug.

This did not cleanly apply, since there were additional changes to btree.c in openzfs/zfs made by this commit:

https://github.com/openzfs/zfs/commit/c0bf952c846100750f526c2a32ebec17694a201b

Anyway, I manually applied the change to produce the commit in this PR. I hope this is helpful.