### PR TITLE
Add const qualifier for pam_conv.conv

### DIFF
--- a/usr/src/lib/libpam/pam_appl.h
+++ b/usr/src/lib/libpam/pam_appl.h
@@ -138,7 +138,7 @@ struct pam_response {
  * call back function pointers and application data pointers to the scheme
  */
 struct pam_conv {
-	int (*conv)(int, struct pam_message **,
+	int (*conv)(int, const struct pam_message **,
 	    struct pam_response **, void *);
 	void *appdata_ptr;		/* Application data ptr */
 };


### PR DESCRIPTION
In [pam_start.3pam](https://github.com/illumos/illumos-gate/blob/master/usr/src/man/man3pam/pam_start.3pam#L50), it claims that the second parameter of conv() has a const qualifier.  However, it isn't true in [the code](https://github.com/illumos/illumos-gate/blob/master/usr/src/lib/libpam/pam_appl.h#L140).
